### PR TITLE
Updating issue templates so that checkboxes will not be created

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,12 +6,8 @@ about: Create a report to help us improve
 
 ### *Product:* (OC-SDR, OC-LTE, OC-LTE, OC-Power, others)
       
-### *Category:*
-   - [ ] Hardware
-   - [ ] Software/stack
-   - [ ] Firmware/bootloader 
-   - [ ] Documentation
-
+### *Category:* (Hardware, Software/stack, Firmware/bootloader, Documentation)
+   
 **Describe the issue found**
 A clear and concise description of what you happened. 
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,12 +8,8 @@ about: Suggest an idea/new feature for OpenCellular
    
 ### *Component:* (PSU, GBC, BBU, FEM, LED, ME)
    
-### *Category:*
-   - [ ] Hardware
-   - [ ] Software/stack
-   - [ ] Firmware/bootloader 
-   - [ ] Documentation
-
+### *Category:* (Hardware, Software/stack, Firmware/bootloader, Documentation)
+   
 **Describe the solution you'd like**
 A clear and concise description of what you want to happen. Ex. Band28 FEM support for LTE [...]
 


### PR DESCRIPTION
The checkboxes in feature_request and bug_report templates were causing the issues to display "1 of 4" status progress, so removing those for just similar to how EVT/DVT does it with just listing category.