### PR TITLE
Cleanup test suite warnings

### DIFF
--- a/firmware/ec/test/Makefile
+++ b/firmware/ec/test/Makefile
@@ -36,6 +36,8 @@ CFLAGS += -Wold-style-definition
 CFLAGS += -DTEST -DUT_POST -DUT_FRAMEWORK
 CFLAGS += -g
 CFLAGS += -Dxdc_target_types__="xdc_target_posix.h"
+# Short enums are assumed throughout the code, need the -fshort-enums flag
+CFLAGS += -fshort-enums
 
 INC_DIRS=-I. -Isrc -I$(UNITY_ROOT)/src -I$(OCWARE_ROOT) -I$(OCWARE_ROOT)/src -Ixdc_stubs -I$(DIR_SYSBIOS) -I$(DIR_TIDRIVERS) -I$(DIR_XDC)
 

--- a/firmware/ec/test/fake/fake_GPIO.h
+++ b/firmware/ec/test/fake/fake_GPIO.h
@@ -24,5 +24,6 @@ typedef struct FakeGpio_Obj {
 extern const OcGpio_FnTable FakeGpio_fnTable;
 
 void FakeGpio_triggerInterrupt(const OcGpio_Pin *pin);
+void FakeGpio_registerDevSimple(void *GpioPins, void *GpioConfig);
 
 #endif /* FAKE_GPIO_H_ */

--- a/firmware/ec/test/suites/Test_GpioSX1509.c
+++ b/firmware/ec/test/suites/Test_GpioSX1509.c
@@ -147,15 +147,6 @@ static const OcGpio_Port s_sx1509_ioexp = {
     .object_data = &(SX1509_Obj){},
 };
 
-static const OcGpio_Port s_invalid_ioexp = {
-    .fn_table = &GpioSX1509_fnTable,
-    .cfg = &(SX1509_Cfg) {
-        .i2c_dev = { I2C_BUS, 0x01 },
-    },
-    .object_data = &(SX1509_Obj){},
-};
-
-static const OcGpio_Pin s_invalid_pin = { &s_invalid_ioexp, 0 };
 static OcGpio_Pin s_test_pins[16];
 
 /* ============================= Boilerplate ================================ */

--- a/firmware/ec/test/suites/Test_OcGpio.c
+++ b/firmware/ec/test/suites/Test_OcGpio.c
@@ -51,25 +51,25 @@ void suite_tearDown(void)
 {
 }
 
-void test_ocgpio_init()
+void test_ocgpio_init(void)
 {
     TEST_ASSERT_EQUAL(OCGPIO_SUCCESS, OcGpio_init(&s_fake_io_port));
 }
 
-void test_ocgpio_read()
+void test_ocgpio_read(void)
 {
     OcGpio_GpioPins[1] = 1;
     TEST_ASSERT_EQUAL(1, OcGpio_read(&s_fake_pin));
 }
 
-void test_ocgpio_write()
+void test_ocgpio_write(void)
 {
     OcGpio_GpioPins[1] = 1;
     TEST_ASSERT_EQUAL(OCGPIO_SUCCESS, OcGpio_write(&s_fake_pin, 0));
     TEST_ASSERT_EQUAL(0, OcGpio_GpioPins[1]);
 }
 
-void test_ocgpio_configure()
+void test_ocgpio_configure(void)
 {
     OcGpio_GpioPins[1] = 1;
     TEST_ASSERT_EQUAL(OCGPIO_SUCCESS, OcGpio_configure(&s_fake_pin, 8));

--- a/firmware/ec/test/suites/Test_PinGroup_driver.c
+++ b/firmware/ec/test/suites/Test_PinGroup_driver.c
@@ -27,10 +27,6 @@ static uint8_t PCA9557_regs[] = {
     [0x02] = 0x00, /* Polarity */
     [0x03] = 0x00, /* Dir Config */
 };
-static const I2C_Dev pca9557_dev = {
-    .bus = 2,
-    .slave_addr = 0x24,
-};
 OcGpio_Port fe_ch1_gain_io = {
     .fn_table = &GpioPCA9557_fnTable,
     .cfg = &(PCA9557_Cfg) {

--- a/firmware/ec/test/suites/Test_eeprom.c
+++ b/firmware/ec/test/suites/Test_eeprom.c
@@ -51,13 +51,6 @@ static Eeprom_Cfg s_dev = {
     },
 };
 
-static Eeprom_Cfg s_invalid_dev = {
-    .i2c_dev = {
-        .bus = 6,
-        .slave_addr = 0xFF,
-    },
-};
-
 static uint16_t EEPROM_regs[] = {
     [0x00] = 0x00, /* Init */
     [0xC601] = 0x00, /* SERIAL INFO */
@@ -206,37 +199,32 @@ OcGpio_Pin pin_inven_eeprom_wp      = { &s_fake_io_exp, 2, 32 };
 Eeprom_Cfg eeprom_gbc_sid = {
     .i2c_dev = { 6, 0x51 },
     .pin_wp = &(OcGpio_Pin){ &s_fake_io_port, 5 },
-    .type = NULL,
+    .type = {0, 0},
     .ss = 0,
 };
 
 Eeprom_Cfg eeprom_gbc_inv = {
     .i2c_dev = { 6, 0x50 },
     .pin_wp = &(OcGpio_Pin){ &s_fake_io_port, 5 },
-    .type = NULL,
+    .type = {0, 0},
     .ss = 0,
 };
 
 Eeprom_Cfg eeprom_sdr_inv = {
     .i2c_dev = { 3, 0x50 },
     .pin_wp = NULL,
-    .type = NULL,
+    .type = {0, 0},
     .ss = 0,
 };
 
 Eeprom_Cfg eeprom_fe_inv = {
     .i2c_dev = { 4, 0x50 },
     .pin_wp = &(OcGpio_Pin){ &s_fake_io_port, 5 },
-    .type = NULL,
+    .type = {0, 0},
     .ss = 8,
 };
 
 /* ============================= Boilerplate ================================ */
-void EEPROM_init(Eeprom_Cfg *s_dev)
-{
-    int8_t ret = 0;
-}
-
 void suite_setUp(void)
 {
     fake_I2C_init();
@@ -261,8 +249,6 @@ void setUp(void)
     OcGpio_init(&s_fake_io_port);
 
     OcGpio_init(&s_fake_io_exp);
-
-    EEPROM_init(&s_dev);
 }
 
 void tearDown(void)
@@ -324,7 +310,7 @@ void test_eeprom_disable_write(void)
     Eeprom_Cfg i_dev = {
         .i2c_dev = { 6, 0x45 },
         .pin_wp = &pin_inven_eeprom_wp,
-        .type = NULL,
+        .type = {0, 0},
         .ss = 0,
     };
 
@@ -340,7 +326,7 @@ void test_eeprom_enable_write(void)
     Eeprom_Cfg i_dev = {
         .i2c_dev = { 6, 0x45 },
         .pin_wp = &pin_inven_eeprom_wp,
-        .type = NULL,
+        .type = {0, 0},
         .ss = 0,
     };
     TEST_ASSERT_EQUAL(RETURN_OK, eeprom_enable_write(&i_dev));
@@ -354,7 +340,7 @@ void test_eeprom_read_board_info(void)
     Eeprom_Cfg b1_dev = {
         .i2c_dev = { 6, 0x50 },
         .pin_wp = &(OcGpio_Pin){ &s_fake_io_port, 5 },
-        .type = NULL,
+        .type = {0, 0},
         .ss = 0,
     };
     TEST_ASSERT_EQUAL(RETURN_OK, eeprom_read_board_info(&b1_dev, &rominfo));
@@ -363,7 +349,7 @@ void test_eeprom_read_board_info(void)
     Eeprom_Cfg b2_dev = {
         .i2c_dev = { 6, 0x50 },
         .pin_wp = &(OcGpio_Pin){ &s_fake_io_port, 5 },
-        .type = NULL,
+        .type = {0, 0},
         .ss = 7,
     };
     EEPROM_regs[0xAC01] = 0x06;
@@ -373,7 +359,7 @@ void test_eeprom_read_board_info(void)
     Eeprom_Cfg b3_dev = {
         .i2c_dev = { 6, 0x50 },
         .pin_wp = &(OcGpio_Pin){ &s_fake_io_port, 5 },
-        .type = NULL,
+        .type = {0, 0},
         .ss = 8,
     };
     EEPROM_regs[0xAC01] = 0x07;
@@ -401,7 +387,7 @@ void test_eeprom_read_device_info_record(void)
     Eeprom_Cfg c1_dev = {
         .i2c_dev = { 6, 0x50 },
         .pin_wp = &(OcGpio_Pin){ &s_fake_io_port, 5 },
-        .type = NULL,
+        .type = {0, 0},
         .ss = 0,
     };
     memset(deviceinfo,0,10);
@@ -415,7 +401,7 @@ void test_eeprom_read_device_info_record(void)
     Eeprom_Cfg c2_dev = {
         .i2c_dev = { 6, 0x50 },
         .pin_wp = &(OcGpio_Pin){ &s_fake_io_port, 5 },
-        .type = NULL,
+        .type = {0, 0},
         .ss = 7,
     };
     memset(deviceinfo1,0,10);
@@ -429,7 +415,7 @@ void test_eeprom_read_device_info_record(void)
     Eeprom_Cfg c3_dev = {
         .i2c_dev = { 6, 0x50 },
         .pin_wp = &(OcGpio_Pin){ &s_fake_io_port, 5 },
-        .type = NULL,
+        .type = {0, 0},
         .ss = 8,
     };
     memset(deviceinfo2,0,10);
@@ -448,7 +434,7 @@ void test_eeprom_write_device_info_record(void)
     Eeprom_Cfg d1_dev = {
         .i2c_dev = { 6, 0x51 },
         .pin_wp = &(OcGpio_Pin){ &s_fake_io_port, 5 },
-        .type = NULL,
+        .type = {0, 0},
         .ss = 0,
     };
 
@@ -459,7 +445,7 @@ void test_eeprom_write_device_info_record(void)
     Eeprom_Cfg d2_dev = {
         .i2c_dev = { 6, 0x51 },
         .pin_wp = &(OcGpio_Pin){ &s_fake_io_port, 5 },
-        .type = NULL,
+        .type = {0, 0},
         .ss = 0,
     };
 
@@ -470,7 +456,7 @@ void test_eeprom_write_device_info_record(void)
     Eeprom_Cfg d3_dev = {
         .i2c_dev = { 6, 0x51 },
         .pin_wp = &(OcGpio_Pin){ &s_fake_io_port, 5 },
-        .type = NULL,
+        .type = {0, 0},
         .ss = 0,
     };
 

--- a/firmware/ec/test/suites/Test_ltc4275.c
+++ b/firmware/ec/test/suites/Test_ltc4275.c
@@ -39,10 +39,15 @@ void test_alert(void)
 {
 }
 
+// Parameters are not used as this is just used to test assigning the 
+//   alert_handler right now.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 static void alert_handler(LTC4275_Event evt, void *context)
 {
 
 }
+#pragma GCC diagnostic pop
 
 void post_update_POSTData(POSTData *pData, uint8_t I2CBus, uint8_t devAddress, uint16_t manId, uint16_t devId)
 {
@@ -85,7 +90,7 @@ LTC4275_Dev l_dev = {
 
 
 /* ================================ Tests =================================== */
-void test_ltc4275_init()
+void test_ltc4275_init(void)
 {
     LTC4275_GpioPins[0x60] = 0;
     LTC4275_GpioPins[0x40] = 1;
@@ -96,7 +101,7 @@ void test_ltc4275_init()
     TEST_ASSERT_EQUAL(OCGPIO_CFG_INPUT | OCGPIO_CFG_INT_BOTH_EDGES, LTC4275_GpioConfig[0x60]);
 }
 
-void test_ltc4275_get_power_good()
+void test_ltc4275_get_power_good(void)
 {
     ePDPowerState val;
 
@@ -110,7 +115,7 @@ void test_ltc4275_get_power_good()
 
 }
 
-void test_ltc4275_probe()
+void test_ltc4275_probe(void)
 {
     LTC4275_GpioPins[0x60] = 1;
     POSTData postData;
@@ -126,7 +131,7 @@ void test_ltc4275_probe()
     TEST_ASSERT_EQUAL(2, PDStatus_Info.pdalert);
 }
 
-void test_ltc4275_get_class()
+void test_ltc4275_get_class(void)
 {
     LTC4275_GpioPins[0x40] = 1;
     ePDClassType val;
@@ -139,14 +144,15 @@ void test_ltc4275_get_class()
     TEST_ASSERT_EQUAL(LTC4275_CLASSTYPE_1, val);
 }
 
-void test_ltc4275_set_alert_handler()
+void test_ltc4275_set_alert_handler(void)
 {
-    ltc4275_set_alert_handler(&l_dev, alert_handler, 1);
-    TEST_ASSERT_EQUAL(1, (int *)l_dev.obj.cb_context);
+    int context;
+    ltc4275_set_alert_handler(&l_dev, alert_handler, &context);
+    TEST_ASSERT_EQUAL(&context, (int *)l_dev.obj.cb_context);
     TEST_ASSERT_EQUAL(alert_handler, (int *)l_dev.obj.alert_cb);
 }
 
-void test_ltc4275_update_status()
+void test_ltc4275_update_status(void)
 {
     LTC4275_GpioPins[0x60] = 1;
     LTC4275_GpioPins[0x40] = 1;

--- a/firmware/ec/test/suites/Test_ocmp_adt7481.c
+++ b/firmware/ec/test/suites/Test_ocmp_adt7481.c
@@ -20,22 +20,17 @@
 
 extern const Component sys_schema[];
 
-static OcGpio_Port s_fake_io_port = {
-    .fn_table = &FakeGpio_fnTable,
-    .object_data = &(FakeGpio_Obj){},
-};
-
-static const I2C_Dev I2C_DEV = {
+static I2C_Dev I2C_DEV = {
     .bus = 7,
     .slave_addr = 0x2F,
 };
 
-static const I2C_Dev s_invalid_dev = {
+static I2C_Dev s_invalid_dev = {
     .bus = 7,
     .slave_addr = 0x52,
 };
 
-static const I2C_Dev s_invalid_bus = {
+static I2C_Dev s_invalid_bus = {
     .bus = 3,
     .slave_addr = 0x2F,
 };
@@ -75,40 +70,24 @@ static uint8_t ADT7481_regs[] = {
     [0x0F] = 0x00, /* One-Shot W*/
     [0x10] = 0x00, /* Remote 1 Temperature Value Low Byte R*/
     [0x11] = 0x00, /* Remote 1 Temperature Offset High Byte R*/
-    [0x11] = 0x00, /* Remote 1 Temperature Offset High Byte W*/
     [0x12] = 0x00, /* Remote 1 Temperature Offset Low Byte R*/
-    [0x12] = 0x00, /* Remote 1 Temperature Offset Low Byte W*/
     [0x13] = 0x00, /* Remote 1 Temp High Limit Low Byte R*/
-    [0x13] = 0x00, /* Remote 1 Temp High Limit Low Byte W*/
     [0x14] = 0x00, /* Remote 1 Temp Low Limit Low Byte R*/
-    [0x14] = 0x00, /* Remote 1 Temp Low Limit Low Byte W*/
     [0x19] = 0x00, /* Remote 1 THERM Limit R */
-    [0x19] = 0x00, /* Remote 1 THERM Limit W */
     [0x20] = 0x00, /* Local THERM Limit R*/
-    [0x20] = 0x00, /* Local THERM Limit W*/
     [0x21] = 0x00, /* THERM Hysteresis R*/
-    [0x21] = 0x00, /* THERM Hysteresis W*/
     [0x22] = 0x00, /* Consecutive ALERT R*/
-    [0x22] = 0x00, /* Consecutive ALERT W*/
     [0x23] = 0x00, /* Status Register 2 R */
     [0x24] = 0x00, /* Configuration 2 Register R*/
-    [0x24] = 0x00, /* Configuration 2 Register W*/
     [0x30] = 0x00, /* Remote 2 Temperature Value High Byte R */
     [0x31] = 0x00, /* Remote 2 Temp High Limit High Byte R*/
-    [0x31] = 0x00, /* Remote 2 Temp High Limit High Byte W*/
     [0x32] = 0x00, /* Remote 2 Temp Low Limit High Byte R*/
-    [0x32] = 0x00, /* Remote 2 Temp Low Limit High Byte W*/
     [0x33] = 0x00, /* Remote 2 Temperature Value Low Byte R*/
     [0x34] = 0x00, /* Remote 2 Temperature Offset High Byte R*/
-    [0x34] = 0x00, /* Remote 2 Temperature Offset High Byte W*/
     [0x35] = 0x00, /* Remote 2 Temperature Offset Low Byte R*/
-    [0x35] = 0x00, /* Remote 2 Temperature Offset Low Byte W*/
     [0x36] = 0x00, /* Remote 2 Temp High Limit Low Byte R */
-    [0x36] = 0x00, /* Remote 2 Temp High Limit Low Byte W */
     [0x37] = 0x00, /* Remote 2 Temp Low Limit Low Byte R*/
-    [0x37] = 0x00, /* Remote 2 Temp Low Limit Low Byte W*/
     [0x39] = 0x00, /* Remote 2 THERM Limit R*/
-    [0x39] = 0x00, /* Remote 2 THERM Limit W*/
     [0x3D] = 0x00, /* Device ID R */
     [0x3E] = 0x00, /* Manufacturer ID R */ 
 };
@@ -153,7 +132,7 @@ void suite_tearDown(void)
 
 /* ================================ Tests =================================== */
 
-void test_probe()
+void test_probe(void)
 {
     POSTData postData;
 
@@ -177,7 +156,7 @@ void test_probe()
             ADT7481_fxnTable.cb_probe(&I2C_DEV, &postData));
 }
 
-void test_get_status()
+void test_get_status(void)
 {
     uint8_t tempvalue = 0xff;
     ADT7481_regs[0x30] = 0x73;
@@ -198,7 +177,7 @@ void test_get_status()
                                     40, &tempvalue));
 }
 
-void test_set_config()
+void test_set_config(void)
 {
     int8_t limit = 0x62;
     
@@ -225,7 +204,7 @@ void test_set_config()
                             40, &limit));
 }
 
-void test_get_config()
+void test_get_config(void)
 {
     int8_t limit = 0xFF;
     ADT7481_regs[0x31] = 0xA2;
@@ -254,7 +233,7 @@ void test_get_config()
                             40, &limit));
 }
 
-void test_init()
+void test_init(void)
 {
     const ADT7481_Config fact_sdr_fpga_adt7481_cfg = {
         .lowlimit = -20,

--- a/firmware/ec/test/suites/Test_ocmp_ltc4274.c
+++ b/firmware/ec/test/suites/Test_ocmp_ltc4274.c
@@ -25,17 +25,17 @@ static OcGpio_Port s_fake_io_port = {
     .object_data = &(FakeGpio_Obj){},
 };
 
-static const I2C_Dev I2C_DEV = {
+static I2C_Dev I2C_DEV = {
     .bus = 7,
     .slave_addr = 0x2F,
 };
 
-static const I2C_Dev I2C_INVALID_DEV = {
+static I2C_Dev I2C_INVALID_DEV = {
     .bus = 7,
     .slave_addr = 0x52,
 };
 
-static const I2C_Dev I2C_INVALID_BUS = {
+static I2C_Dev I2C_INVALID_BUS = {
     .bus = 3,
     .slave_addr = 0x2F,
 };
@@ -171,14 +171,19 @@ void suite_tearDown(void)
 }
 
 /* ================================ Tests =================================== */
+// Parameters are not used as this is just used to test assigning the 
+//   alert_handler right now.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 void OCMP_GenerateAlert(const AlertData *alert_data,
                         unsigned int alert_id,
                         const void *data)
 {
     return;
 }
+#pragma GCC diagnostic pop
 
-void test_probe()
+void test_probe(void)
 {
     POSTData postData;
 
@@ -201,7 +206,7 @@ void test_probe()
             LTC4274_fxnTable.cb_probe(&s_dev, &postData));
 }
 
-void test_get_status()
+void test_get_status(void)
 {
     uint8_t value = 0xFF;
 
@@ -247,7 +252,7 @@ void test_get_status()
 
 }
 
-void test_set_config()
+void test_set_config(void)
 {
     uint8_t value = 0x00;
     
@@ -309,7 +314,7 @@ void test_set_config()
                 LTC4274_CONFIG_HP_ENABLE, &value));
 }
 
-void test_get_config()
+void test_get_config(void)
 {
     uint8_t value = 0x00;
     
@@ -365,8 +370,10 @@ void test_get_config()
                 LTC4274_CONFIG_HP_ENABLE, &value));
 }
 
-void test_init()
+void test_init(void)
 {
+    
+    const int alert_token;
 
     const LTC4274_Config fact_ltc4274_cfg = {
         .operatingMode = LTC4274_AUTO_MODE,
@@ -377,7 +384,7 @@ void test_init()
     };
     
     TEST_ASSERT_EQUAL(POST_DEV_CFG_DONE, LTC4274_fxnTable.cb_init(&s_dev,
-            &fact_ltc4274_cfg, 1));
+            &fact_ltc4274_cfg, &alert_token));
 
     TEST_ASSERT_EQUAL_HEX8(LTC4274_regs[0x12], LTC4274_AUTO_MODE);
     TEST_ASSERT_EQUAL_HEX8(LTC4274_regs[0x14], LTC4274_DETECT_ENABLE);
@@ -388,7 +395,7 @@ void test_init()
                             LTC7274_GpioConfig[27]);
                             
     TEST_ASSERT_EQUAL(POST_DEV_CFG_FAIL, LTC4274_fxnTable.cb_init(&s_invalid_dev,
-            &fact_ltc4274_cfg, 1));
+            &fact_ltc4274_cfg, &alert_token));
     TEST_ASSERT_EQUAL(POST_DEV_CFG_DONE, LTC4274_fxnTable.cb_init(&s_dev,
-            NULL, 1));
+            NULL, &alert_token));
 }

--- a/firmware/ec/test/suites/Test_pca9557.c
+++ b/firmware/ec/test/suites/Test_pca9557.c
@@ -14,9 +14,6 @@
 #include <string.h>
 
 /* ======================== Constants & variables =========================== */
-static const unsigned int I2C_BUS = 2;
-static const uint8_t I2C_ADDR = 0x00;
-
 static uint8_t PCA9557_regs[] = {
     [0x00] = 0x00, /* Input values */
     [0x01] = 0x00, /* Output values */

--- a/firmware/ec/test/suites/Test_powerSource.c
+++ b/firmware/ec/test/suites/Test_powerSource.c
@@ -206,7 +206,7 @@ static PWRSRC_Dev p_dev = {
 };
 /* ================================ Tests =================================== */
 
-void test_pwr_process_get_status_parameters_data_poeavailable()
+void test_pwr_process_get_status_parameters_data_poeavailable(void)
 {
     uint8_t powerStatus = 0;
     uint8_t index = 0x00;          //PoE Availability    
@@ -222,7 +222,7 @@ void test_pwr_process_get_status_parameters_data_poeavailable()
     TEST_ASSERT_EQUAL(1, powerStatus);
 }
 
-void test_pwr_process_get_status_parameters_data_poeaccessible()
+void test_pwr_process_get_status_parameters_data_poeaccessible(void)
 {
     uint8_t powerStatus = 0;
     uint8_t index = 0x01;          //PoE Accessibility    
@@ -238,7 +238,7 @@ void test_pwr_process_get_status_parameters_data_poeaccessible()
     TEST_ASSERT_EQUAL(1, powerStatus);
 }
 
-void test_pwr_process_get_status_parameters_data_solaravailable()
+void test_pwr_process_get_status_parameters_data_solaravailable(void)
 {
     uint8_t powerStatus = 0;
     uint8_t index = 0x02;          //SOLAR Availability
@@ -254,7 +254,7 @@ void test_pwr_process_get_status_parameters_data_solaravailable()
     TEST_ASSERT_EQUAL(1, powerStatus);
 }
 
-void test_pwr_process_get_status_parameters_data_solaraccessible()
+void test_pwr_process_get_status_parameters_data_solaraccessible(void)
 {
     uint8_t powerStatus = 0;         
     uint8_t index = 0x03;          //SOLAR Accessibility
@@ -270,7 +270,7 @@ void test_pwr_process_get_status_parameters_data_solaraccessible()
     TEST_ASSERT_EQUAL(1, powerStatus);
 }
 
-void test_pwr_process_get_status_parameters_data_extavailable()
+void test_pwr_process_get_status_parameters_data_extavailable(void)
 {
     uint8_t powerStatus = 0;
     uint8_t index = 0x04;           //Ext Batt availability
@@ -286,7 +286,7 @@ void test_pwr_process_get_status_parameters_data_extavailable()
     TEST_ASSERT_EQUAL(1, powerStatus);
 }
 
-void test_pwr_process_get_status_parameters_data_extaccessible()
+void test_pwr_process_get_status_parameters_data_extaccessible(void)
 {
     uint8_t powerStatus = 0;
     uint8_t index = 0x05;          //Ext Batt accessibility
@@ -302,7 +302,7 @@ void test_pwr_process_get_status_parameters_data_extaccessible()
     TEST_ASSERT_EQUAL(1, powerStatus);
 }
 
-void test_pwr_process_get_status_parameters_data_intavailable()
+void test_pwr_process_get_status_parameters_data_intavailable(void)
 {
    uint8_t powerStatus = 0;
    uint8_t index = 0x06;           //Int Batt Availability   
@@ -318,7 +318,7 @@ void test_pwr_process_get_status_parameters_data_intavailable()
    TEST_ASSERT_EQUAL(1, powerStatus);
 }
 
-void test_pwr_process_get_status_parameters_data_intaccessible()
+void test_pwr_process_get_status_parameters_data_intaccessible(void)
 {
     uint8_t powerStatus = 0;
     uint8_t index = 0x07;          //Int Batt Accessibility


### PR DESCRIPTION
To address #104 (list item 1), fixed all the warnings created by the Test_* files in test/suites/ . Added a [file](https://github.com/Telecominfraproject/OpenCellular/files/2442839/testSuiteWarnings.txt) with the list of all the warnings that are issued by `make clean test` before these changes. 
No functionality should be changed in the Test_*.c files. 

Also added the `-fshort-enums` flag to the CFLAGS in test/Makefile since short enums are assumed throughout the code. This causes some tests to fail, I believe these tests are failing correctly and should have been failing before, but were not being run correctly due to the enums being integers and overwriting memory they should not have been. 
