### PR TITLE
Misc warnings fixes

### DIFF
--- a/firmware/ec/common/inc/global/post_frame.h
+++ b/firmware/ec/common/inc/global/post_frame.h
@@ -40,4 +40,10 @@ typedef struct __attribute__((packed, aligned(1))) {
     uint8_t status;
 } POSTData;
 
+/*****************************************************************************
+ *                         FUNCTION PROTOTYPES 
+ *****************************************************************************/
+void post_update_POSTData(POSTData *pData, uint8_t I2CBus, uint8_t devAddress, 
+                                 uint16_t manId, uint16_t devId);
+
 #endif /* POST_FRAME_H_ */

--- a/firmware/ec/inc/devices/adt7481.h
+++ b/firmware/ec/inc/devices/adt7481.h
@@ -103,6 +103,8 @@ ReturnStatus adt7481_get_dev_id(const I2C_Dev *i2c_dev,
                                 uint8_t *devID);
 ReturnStatus adt7481_get_mfg_id(const I2C_Dev *i2c_dev,
                                 uint8_t *mfgID);
+ePostCode adt7481_probe(const I2C_Dev *i2c_dev,
+                              POSTData *postData);
 ReturnStatus adt7481_get_config1(const I2C_Dev *i2c_dev,
                                  uint8_t *configValue);
 ReturnStatus adt7481_set_config1(const I2C_Dev *i2c_dev,

--- a/firmware/ec/inc/devices/eeprom.h
+++ b/firmware/ec/inc/devices/eeprom.h
@@ -62,7 +62,7 @@ typedef enum {
  *****************************************************************************/
 bool eeprom_init(Eeprom_Cfg *cfg);
 
-ReturnStatus eeprom_read(Eeprom_Cfg *cfg,
+ReturnStatus eeprom_read(const Eeprom_Cfg *cfg,
                          uint16_t address,
                          void *buffer,
                          size_t size);

--- a/firmware/ec/src/devices/eeprom.c
+++ b/firmware/ec/src/devices/eeprom.c
@@ -79,7 +79,7 @@ bool eeprom_init(Eeprom_Cfg *cfg) {
  **    RETURN TYPE     : Success or failure
  **
  *****************************************************************************/
-ReturnStatus eeprom_read(Eeprom_Cfg *cfg,
+ReturnStatus eeprom_read(const Eeprom_Cfg *cfg,
                          uint16_t address,
                          void *buffer,
                          size_t size)

--- a/firmware/ec/src/devices/ltc4275.c
+++ b/firmware/ec/src/devices/ltc4275.c
@@ -263,6 +263,6 @@ void ltc4275_update_status(const LTC4275_Dev *dev)
     } else {
         PDStatus_Info.state = LTC4275_STATE_NOTOK;
         PDStatus_Info.pdalert = LTC4275_DISCONNECT_ALERT;
-        PDStatus_Info.pdStatus.classStatus == LTC4275_CLASSTYPE_UNKOWN;
+        PDStatus_Info.pdStatus.classStatus = LTC4275_CLASSTYPE_UNKOWN;
     }
 }

--- a/firmware/ec/src/devices/ocmp_wrappers/ocmp_adt7481.c
+++ b/firmware/ec/src/devices/ocmp_wrappers/ocmp_adt7481.c
@@ -89,6 +89,10 @@ static ePostCode _probe(void *driver, POSTData *postData)
     return adt7481_probe(driver,postData);
 }
 
+// alert_token currently intentionally unused, so disabling unused-parameter
+// check
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 static ePostCode _init(void *driver, const void *config,
                        const void *alert_token)
 {
@@ -96,7 +100,7 @@ static ePostCode _init(void *driver, const void *config,
     if (adt7481_config == NULL) {
         return POST_DEV_CFG_FAIL;
     }
-    for (int i = 0; i < ARRAY_SIZE(adt7481_config->limits); ++i) {
+    for (size_t i = 0; i < ARRAY_SIZE(adt7481_config->limits); ++i) {
         if (adt7481_set_local_temp_limit(
                 driver, i + 1, adt7481_config->limits[i]) != RETURN_OK ||
             adt7481_set_remote1_temp_limit(
@@ -119,6 +123,7 @@ static ePostCode _init(void *driver, const void *config,
 
     return POST_DEV_CFG_DONE;
 }
+#pragma GCC diagnostic pop
 
 /* TODO: dedup with SE98A driver */
 /* TODO: enable alerts (requires major ADT driver changes) */

--- a/firmware/ec/src/devices/ocmp_wrappers/ocmp_ltc4274.c
+++ b/firmware/ec/src/devices/ocmp_wrappers/ocmp_ltc4274.c
@@ -38,12 +38,16 @@ typedef enum LTC7274Alert {
     LTC4274_ALERT_SUPPLY
 } LTC7274Alert;
 
+// *params not needed by reset but kept in definition to match CB_Command type.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 bool LTC4274_reset(void *driver, void *params)
 {
 	ReturnStatus status = RETURN_OK;
 	status = ltc4274_reset(driver);
 	return status;
 }
+#pragma GCC diagnostic pop
 
 static bool _get_status(void *driver, unsigned int param_id,
         void *return_buf) {

--- a/firmware/ec/src/devices/powerSource.c
+++ b/firmware/ec/src/devices/powerSource.c
@@ -94,7 +94,7 @@ void pwr_source_config(PWRSRC_Dev* driver)
  **     RETURN TYPE    : None
  **
  *****************************************************************************/
-void pwr_source_init()
+void pwr_source_init(void)
 {
     ePowerSource itr = PWR_SRC_AUX_OR_SOLAR ;
     for (; itr < PWR_SRC_MAX; itr++) {

--- a/firmware/ec/src/drivers/GpioSX1509.c
+++ b/firmware/ec/src/drivers/GpioSX1509.c
@@ -58,7 +58,6 @@ static void HandleIRQ(void *context) {
 static int GpioSX1509_probe(const OcGpio_Port *port) {
     /* if we are able to read configuration register this means PCA device is accessible*/
     const SX1509_Cfg *sx_cfg = port->cfg;
-    SX1509_Obj *obj = port->object_data;
     uint8_t input_reg;
     if (ioexp_led_get_data(&sx_cfg->i2c_dev, 0, &input_reg) != RETURN_OK) {
         return OCGPIO_FAILURE;

--- a/firmware/ec/src/post/post_util.c
+++ b/firmware/ec/src/post/post_util.c
@@ -16,7 +16,6 @@
 extern const Component sys_schema[OC_SS_MAX_LIMIT];
 extern OCSubsystem *ss_reg[SUBSYSTEM_COUNT];
 POSTData PostResult[POST_RECORDS] = { { 0 } };
-static uint8_t deviceCount = 0;
 
 #ifdef UT_POST
 /*
@@ -50,6 +49,8 @@ void post_update_POSTData(POSTData *pData, uint8_t I2CBus, uint8_t devAddress, u
     pData->devId = devId;
 }
 #else
+static uint8_t deviceCount = 0;
+
 /* Execute POST for a given device driver (performs deep copy of alert_data) */
 static ePostCode _postDriver(const Component *subsystem,
                                 const Component *dev,

--- a/firmware/ec/test/Makefile
+++ b/firmware/ec/test/Makefile
@@ -20,6 +20,7 @@ C_COMPILER=clang
 endif
 
 CFLAGS  = -std=c99
+CFLAGS += -Werror
 CFLAGS += -Wall
 CFLAGS += -Wextra
 CFLAGS += -Wpointer-arith


### PR DESCRIPTION
Last few miscellaneous fixes to get rid of all Unit Test warnings. Last commit addes `-Werror` flag so that we can maintain 0 warnings going forward.