### PR TITLE
Env detect

### DIFF
--- a/.ci/coverage.py
+++ b/.ci/coverage.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+from lcov_cobertura import LcovCobertura
+
+LCOV_FILE = 'build/coverage/test-coverage.info'
+OUT_FILE = 'build/coverage/test-coverage.xml'
+
+with open(LCOV_FILE) as fr:
+    data = fr.read()
+
+converter = LcovCobertura(data)
+res = converter.convert()
+
+with open(OUT_FILE, 'w') as fw:
+    fw.write(res)

--- a/firmware/ec/Makefile
+++ b/firmware/ec/Makefile
@@ -79,7 +79,7 @@ LLIBS += -Wl,--end-group
 
 OBJCOPY = $(TOOLCHAIN)/bin/arm-none-eabi-objcopy
 
-all: oc_connect1
+all: get_cfg oc_connect1
 oc_connect1: $(OUT)/OpenCellular.bin
 
 $(OUT)/%/compiler.opt $(OUT)/%/linker.cmd : %.cfg
@@ -98,6 +98,8 @@ $(OUT)/OpenCellular.bin: $(OUT)/OpenCellular.out
 clean:
 	-rm -rf *.o *.out *.d *.rov.xs $(OUT) $(MAIN_OBJS) $(COVERAGE_OBJS)
 
+get_cfg:
+	cd ../utilities/build; ./envDetect.sh $(CC) $(TIRTOS_DIR)
 test:
 	cd test && $(MAKE) $(TESTFLAGS)
 

--- a/firmware/ec/Makefile
+++ b/firmware/ec/Makefile
@@ -53,6 +53,7 @@ CONFIGURO = $(XDCTOOLS_DIR)/xs --xdcpath="$(XDCPATH)" \
 # Find all C source/object files.
 SRC_FILE = $(shell find . -name '*.c' ! -path './test/*' ! -path './$(OUT)*')
 MAIN_OBJS = $(SRC_FILE:.c=.o)
+COVERAGE_OBJS = $(SRC_FILE:.c=.gcno)
 
 CC = $(TOOLCHAIN)/bin/arm-none-eabi-gcc
 CFLAGS = -Wall -mcpu=cortex-m4 -mthumb -mabi=aapcs -mapcs-frame @$(OUT)/$(CONFIG)/compiler.opt -O3
@@ -95,10 +96,14 @@ $(OUT)/OpenCellular.bin: $(OUT)/OpenCellular.out
 	$(OBJCOPY) -S -O binary $< $@
 
 clean:
-	-rm -rf *.o *.out *.d *.rov.xs $(OUT) $(MAIN_OBJS)
+	-rm -rf *.o *.out *.d *.rov.xs $(OUT) $(MAIN_OBJS) $(COVERAGE_OBJS)
 
 test:
-	cd test && $(MAKE)
+	cd test && $(MAKE) $(TESTFLAGS)
+
+ci: TESTFLAGS = ci
+ci: CFLAGS += -ftest-coverage
+ci: all test
 
 .PHONY: all oc_connect1 clean test
 

--- a/firmware/ec/test/Makefile
+++ b/firmware/ec/test/Makefile
@@ -10,6 +10,7 @@ OCWARE_ROOT ?= ..
 PATHT = suites/
 PATHB = build/
 PATHR = build/results/
+PATHC = build/coverage/
 RUNNER_PATH = build/runners/
 
 # Compiler Options
@@ -48,9 +49,16 @@ BUILD_PATHS = $(RUNNER_PATH) $(PATHB) $(PATHR)
 SRCT = $(wildcard $(PATHT)*.c)
 TESTS ?= $(patsubst $(PATHT)Test%.c,Test%,$(SRCT))
 RESULTS = $(patsubst %,$(PATHR)%.testresults,$(TESTS))
+COVERAGE = $(patsubst %,$(PATHC)%.info,$(TESTS))
 
 # List of standard files that every test will build (unity, test, test runner)
 STD_FILES=$(PATHB)Test_%$(TARGET_EXTENSION):$(UNITY_ROOT)/src/unity.c $(PATHT)/Test_%.c  build/runners/Test_%_Runner.c
+
+# Create the flags to add all individual coverage files
+LCOV_ADD = $(patsubst %,-a %, $(COVERAGE))
+LCOV_ADD += -a $(PATHC)test-base.info
+# The directories to ignore in coverage
+LCOV_IGNORE = "*/test/*" "*/Unity/*" "*/ti/*"
 
 #We try to detect the OS we are running on, and adjust commands as needed
 ifeq ($(OS),Windows_NT)
@@ -82,70 +90,75 @@ endif
 test: $(BUILD_PATHS) $(RESULTS)
 	ruby $(UNITY_ROOT)/auto/unity_test_summary.rb $(PATHR)
 
+junit: test
+	@ruby $(UNITY_ROOT)/auto/stylize_as_junit.rb -r $(PATHR) -o $(PATHR)/unit-test-results.xml
+
 # Note: we force the rebuild of this target each run to ensure fresh results
 $(PATHR)%.testresults: $(PATHB)%$(TARGET_EXTENSION) FORCE
 	-./$< > $@ 2>&1
 
 $(RUNNER_PATH)Test_%_Runner.c: $(PATHT)Test_%.c
 	ruby $(UNITY_ROOT)/auto/generate_test_runner.rb --suite_setup="extern void suite_setUp(void); suite_setUp();" --suite_teardown="extern void suite_tearDown(void); suite_tearDown(); return num_failures;" $< $@
+
+$(PATHC)test-base.info:
+	@lcov --rc lcov_branch_coverage=1 -c -i -d ../ -o $(PATHC)test-base.info
+
+# Get coverage statistics for every test
+$(COVERAGE): $(PATHC)%.info: $(PATHC)/% $(PATHB)%$(TARGET_EXTENSION) $(PATHC) $(BUILD_PATHS) $(RESULTS)
+	@lcov --rc lcov_branch_coverage=1 -c -d $< -o $@ > /dev/null
+# Combine all test suites coverage info and remove all files that are not src
+coverage: $(COVERAGE) $(PATHC) $(PATHC)test-base.info
+	@lcov --rc lcov_branch_coverage=1 $(LCOV_ADD) -o $(PATHC)/test-coverage-all.info > /dev/null
+	@lcov --rc lcov_branch_coverage=1 --remove $(PATHC)/test-coverage-all.info  $(LCOV_IGNORE) -o $(PATHC)/test-coverage.info
 	
 # Test-specific build rules (add entries here for each new test suite)
 # =============================================================================
+INC_M =-lm
 TEST_PCA9557_SRC=$(OCWARE_ROOT)/src/devices/pca9557.c $(OCWARE_ROOT)/src/devices/i2cbus.c fake/fake_I2C.c
 $(PATHB)Test_pca9557$(TARGET_EXTENSION): $(STD_FILES) $(TEST_PCA9557_SRC)
-	$(C_COMPILER) $(CFLAGS) $(INC_DIRS) $(SYMBOLS) $^ -o $@
 
 TEST_SE98A_SRC=$(OCWARE_ROOT)/src/devices/se98a.c $(OCWARE_ROOT)/src/devices/i2cbus.c fake/fake_GPIO.c fake/fake_I2C.c fake/fake_ThreadedISR.c stub/stub_GateMutex.c $(OCWARE_ROOT)/src/post/post_util.c
-$(PATHB)Test_se98a$(TARGET_EXTENSION): $(STD_FILES) $(TEST_SE98A_SRC)
-	$(C_COMPILER) $(CFLAGS) $(INC_DIRS) $(SYMBOLS) $^ -lm -o $@
+$(PATHB)Test_se98a$(TARGET_EXTENSION): $(STD_FILES) $(TEST_SE98A_SRC) $(INC_M)
 
 TEST_GpioPCA9557_SRC=$(OCWARE_ROOT)/src/devices/pca9557.c $(OCWARE_ROOT)/src/devices/i2cbus.c fake/fake_I2C.c $(OCWARE_ROOT)/src/drivers/GpioPCA9557.c $(OCWARE_ROOT)/src/helpers/memory.c stub/stub_GateMutex.c
 $(PATHB)Test_GpioPCA9557$(TARGET_EXTENSION): $(STD_FILES) $(TEST_GpioPCA9557_SRC)
-	$(C_COMPILER) $(CFLAGS) $(INC_DIRS) $(SYMBOLS) $^ -o $@
 
 TEST_INA226_SRC=$(OCWARE_ROOT)/src/devices/ina226.c $(OCWARE_ROOT)/src/devices/i2cbus.c fake/fake_GPIO.c fake/fake_I2C.c fake/fake_ThreadedISR.c $(OCWARE_ROOT)/src/post/post_util.c
 $(PATHB)Test_ina226$(TARGET_EXTENSION): $(STD_FILES) $(TEST_INA226_SRC)
-	$(C_COMPILER) $(CFLAGS) $(INC_DIRS) $(SYMBOLS) $^ -o $@
 
 TEST_SX1509_SRC=$(OCWARE_ROOT)/src/devices/sx1509.c $(OCWARE_ROOT)/src/devices/i2cbus.c fake/fake_I2C.c
 $(PATHB)Test_sx1509$(TARGET_EXTENSION): $(STD_FILES) $(TEST_SX1509_SRC)
-	$(C_COMPILER) $(CFLAGS) $(INC_DIRS) $(SYMBOLS) $^ -o $@
 
 TEST_GpioSX1509_SRC=$(OCWARE_ROOT)/src/devices/sx1509.c $(OCWARE_ROOT)/src/devices/i2cbus.c fake/fake_I2C.c fake/fake_ThreadedISR.c $(OCWARE_ROOT)/src/drivers/GpioSX1509.c $(OCWARE_ROOT)/src/helpers/memory.c stub/stub_GateMutex.c
 $(PATHB)Test_GpioSX1509$(TARGET_EXTENSION): $(STD_FILES) $(TEST_GpioSX1509_SRC)
-	$(C_COMPILER) $(CFLAGS) $(INC_DIRS) $(SYMBOLS) $^ -o $@
-	
+
 TEST_LTC4015_SRC=$(OCWARE_ROOT)/src/devices/ltc4015.c $(OCWARE_ROOT)/src/devices/i2cbus.c fake/fake_GPIO.c fake/fake_I2C.c fake/fake_ThreadedISR.c $(OCWARE_ROOT)/src/post/post_util.c
-$(PATHB)Test_ltc4015$(TARGET_EXTENSION): $(STD_FILES) $(TEST_LTC4015_SRC)
-	$(C_COMPILER) $(CFLAGS) $(INC_DIRS) $(SYMBOLS) $^ -lm -o $@
-	
+$(PATHB)Test_ltc4015$(TARGET_EXTENSION): $(STD_FILES) $(TEST_LTC4015_SRC) $(INC_M)
+
 TEST_powerSource_SRC=$(OCWARE_ROOT)/src/devices/powerSource.c $(OCWARE_ROOT)/src/drivers/GpioSX1509.c $(OCWARE_ROOT)/src/devices/sx1509.c $(OCWARE_ROOT)/src/helpers/memory.c $(OCWARE_ROOT)/src/devices/i2cbus.c fake/fake_GPIO.c fake/fake_I2C.c fake/fake_ThreadedISR.c stub/stub_GateMutex.c
-$(PATHB)Test_powerSource$(TARGET_EXTENSION): $(STD_FILES) $(TEST_powerSource_SRC)
-	$(C_COMPILER) $(CFLAGS) $(INC_DIRS) $(SYMBOLS) $^ -lm -o $@
+$(PATHB)Test_powerSource$(TARGET_EXTENSION): $(STD_FILES) $(TEST_powerSource_SRC) $(INC_M)
 
 TEST_EEPROM_SRC=$(OCWARE_ROOT)/src/devices/eeprom.c $(OCWARE_ROOT)/src/drivers/GpioSX1509.c $(OCWARE_ROOT)/src/devices/sx1509.c $(OCWARE_ROOT)/src/helpers/memory.c $(OCWARE_ROOT)/src/devices/i2cbus.c fake/fake_GPIO.c fake/fake_I2C.c fake/fake_ThreadedISR.c stub/stub_GateMutex.c
-$(PATHB)Test_eeprom$(TARGET_EXTENSION): $(STD_FILES) $(TEST_EEPROM_SRC)
-	$(C_COMPILER) $(CFLAGS) $(INC_DIRS) $(SYMBOLS) $^ -lm -o $@
+$(PATHB)Test_eeprom$(TARGET_EXTENSION): $(STD_FILES) $(TEST_EEPROM_SRC) $(INC_M)
 
 TEST_LTC4275_SRC=$(OCWARE_ROOT)/src/devices/ltc4275.c $(OCWARE_ROOT)/src/devices/i2cbus.c fake/fake_GPIO.c fake/fake_I2C.c fake/fake_ThreadedISR.c stub/stub_GateMutex.c
-$(PATHB)Test_ltc4275$(TARGET_EXTENSION): $(STD_FILES) $(TEST_LTC4275_SRC)
-	$(C_COMPILER) $(CFLAGS) $(INC_DIRS) $(SYMBOLS) $^ -lm -o $@
+$(PATHB)Test_ltc4275$(TARGET_EXTENSION): $(STD_FILES) $(TEST_LTC4275_SRC) $(INC_M)
 
 TEST_OCMP_ADT7481_SRC=$(OCWARE_ROOT)/src/devices/ocmp_wrappers/ocmp_adt7481.c $(OCWARE_ROOT)/src/devices/adt7481.c $(OCWARE_ROOT)/src/devices/i2cbus.c fake/fake_GPIO.c fake/fake_I2C.c fake/fake_ThreadedISR.c stub/stub_GateMutex.c $(OCWARE_ROOT)/src/post/post_util.c
-$(PATHB)Test_ocmp_adt7481$(TARGET_EXTENSION): $(STD_FILES) $(TEST_OCMP_ADT7481_SRC)
-	$(C_COMPILER) $(CFLAGS) $(INC_DIRS) $(SYMBOLS) $^ -lm -o $@
+$(PATHB)Test_ocmp_adt7481$(TARGET_EXTENSION): $(STD_FILES) $(TEST_OCMP_ADT7481_SRC) $(INC_M)
 
 TEST_OCMP_LTC4274_SRC=$(OCWARE_ROOT)/src/devices/ocmp_wrappers/ocmp_ltc4274.c $(OCWARE_ROOT)/src/devices/ltc4274.c $(OCWARE_ROOT)/src/devices/i2cbus.c fake/fake_GPIO.c fake/fake_I2C.c fake/fake_ThreadedISR.c stub/stub_GateMutex.c $(OCWARE_ROOT)/src/post/post_util.c
-$(PATHB)Test_ocmp_ltc4274$(TARGET_EXTENSION): $(STD_FILES) $(TEST_OCMP_LTC4274_SRC)
-	$(C_COMPILER) $(CFLAGS) $(INC_DIRS) $(SYMBOLS) $^ -lm -o $@
+$(PATHB)Test_ocmp_ltc4274$(TARGET_EXTENSION): $(STD_FILES) $(TEST_OCMP_LTC4274_SRC) $(INC_M)
 
 TEST_PINGROUP_SRC=$(OCWARE_ROOT)/src/drivers/PinGroup.c $(OCWARE_ROOT)/src/devices/i2cbus.c fake/fake_I2C.c fake/fake_ThreadedISR.c $(OCWARE_ROOT)/src/helpers/memory.c stub/stub_GateMutex.c $(OCWARE_ROOT)/src/drivers/GpioPCA9557.c $(OCWARE_ROOT)/src/devices/pca9557.c
 $(PATHB)Test_PinGroup_driver$(TARGET_EXTENSION): $(STD_FILES) $(TEST_PINGROUP_SRC)
-	$(C_COMPILER) $(CFLAGS) $(INC_DIRS) $(SYMBOLS) $^ -o $@    
 
 TEST_OCGPIO_SRC=$(OCWARE_ROOT)/src/drivers/OcGpio.c $(OCWARE_ROOT)/src/devices/i2cbus.c fake/fake_I2C.c fake/fake_GPIO.c fake/fake_ThreadedISR.c $(OCWARE_ROOT)/src/helpers/memory.c stub/stub_GateMutex.c
 $(PATHB)Test_OcGpio$(TARGET_EXTENSION): $(STD_FILES) $(TEST_OCGPIO_SRC)
+
+$(PATHB)%$(TARGET_EXTENSION):
 	$(C_COMPILER) $(CFLAGS) $(INC_DIRS) $(SYMBOLS) $^ -o $@    
+	$(COV_CMDS)
 
 # Dummy target to allow us to force rebuild of testresults every time
 FORCE:
@@ -157,6 +170,9 @@ $(PATHB):
 $(PATHR):
 	$(MKDIR) $(PATHR)
 	
+$(PATHC):
+	$(MKDIR) $(PATHC)
+
 $(RUNNER_PATH):
 	$(MKDIR) $(RUNNER_PATH)
 	
@@ -165,7 +181,17 @@ clean:
 
 .PHONY: clean
 .PHONY: test
+.PHONY: junit
+.PHONY: coverage
 .PHONY: FORCE
 
+# Continuous integration
 ci: CFLAGS += -Werror
-ci: clean test
+ci: CFLAGS += -ftest-coverage -fprofile-arcs -fprofile-dir=$(PATHC)$*/
+ci: COV_CMDS = @mkdir -p $(PATHC)$* && mv *.gcno $(PATHC)$*
+ci: clean junit coverage
+
+# Test Coverage
+cov: CFLAGS += -ftest-coverage -fprofile-arcs -fprofile-dir=$(PATHC)$*/
+cov: COV_CMDS = @mkdir -p $(PATHC)$* && mv *.gcno $(PATHC)$*
+cov: clean test coverage

--- a/firmware/host/Makefile
+++ b/firmware/host/Makefile
@@ -15,7 +15,10 @@ default:
 	@mkdir -p $(output_dir)
 	make all
 	
-all:	ocmw_uart ocmw_usb ocmw_eth occli ocmw_eth_stub ocware_stub
+all:	get_cfg ocmw_uart ocmw_usb ocmw_eth occli ocmw_eth_stub ocware_stub
+
+get_cfg:
+	cd ../utilities/build; ./envDetect.sh
 	
 .PHONY:	occli
 

--- a/firmware/utilities/build/envDetect.sh
+++ b/firmware/utilities/build/envDetect.sh
@@ -1,0 +1,36 @@
+#!/bin/sh -e
+BUILDHOST=$(uname -a)
+GCCVER=$(gcc --version)
+GITHASH=$(git rev-parse HEAD)
+if [ $# = 2 ]; then
+  BUILDTYPE="\tEC Build"
+  BUILDFNAME="build_ec_cfg.txt"
+  if [ -e "$1" ]; then
+    ARMVER=$($1 --version)
+  else
+    ARMVER="arm-none-eabi-gcc: Not found"
+  fi
+  if [ -d "$2" ]; then
+    TIRTOSVER="TI RTOS: $2"
+  else
+    TIRTOSVER="TI RTOS: Not found"
+  fi
+else
+  BUILDTYPE="\tHost Build"
+  BUILDFNAME="build_host_cfg.txt"
+  ARMVER=""
+  TIRTOSVER=""
+fi
+{
+echo "$BUILDTYPE"
+echo
+echo "GIT Hash: $GITHASH"
+echo
+echo "Build Host: $BUILDHOST"
+echo
+echo "$GCCVER"
+echo
+echo "$ARMVER"
+echo
+echo "$TIRTOSVER"
+} > $BUILDFNAME


### PR DESCRIPTION
## Summary
firmware/utilities/build includes a shell script that detects the build environment.  I works in both Windows and Linux.

## Test Plan
1. Build from firmware/ec. Verify that `firmware/utilities/build/build_ec_cfg.txt` is created and firmware builds with no new issues.  The text file should be created even if the build fails.
2. Build from firmware/host. Verify that `firmware/utilities/build/build_host_cfg.txt` is created and host builds with no new issues.  The text file should be created even if the build fails.

## Issues
Fixes Issue #171 . 
