### PR TITLE
Compatibility changes for gcc 7.3

### DIFF
--- a/firmware/ec/Makefile
+++ b/firmware/ec/Makefile
@@ -84,7 +84,11 @@ LINT_FLAGS = -i -style=file -fallback-style=none
 
 .PRECIOUS: %/compiler.opt %/linker.cmd
 
-all: oc_connect1
+all: oc_connect1 hash
+
+hash:
+	cd ../utilities/checksums; ./hashes.sh $(shell pwd)/$(OUT) -ec
+
 oc_connect1: $(OUT)/OpenCellular.bin
 
 $(OUT)/%/compiler.opt $(OUT)/%/linker.cmd : %.cfg

--- a/firmware/host/Makefile
+++ b/firmware/host/Makefile
@@ -15,8 +15,11 @@ default:
 	@mkdir -p $(output_dir)
 	make all
 	
-all:	ocmw_uart ocmw_usb ocmw_eth occli ocmw_eth_stub ocware_stub
-	
+all:	ocmw_uart ocmw_usb ocmw_eth occli ocmw_eth_stub ocware_stub hash
+
+hash:
+	cd ../utilities/checksums; ./hosthash.sh $(shell pwd)/$(output_dir)
+
 .PHONY:	occli
 
 ocmw_uart:   $(OBJECTS)
@@ -41,4 +44,4 @@ occli:   $(OBJECTS)
 
 # --- remove binary and executable files
 clean:
-	rm -fr $(output_dir)/ocmw_eth_stub $(output_dir)/ocmw_eth $(output_dir)/ocmw_usb $(output_dir)/ocmw_uart $(output_dir)/occli $(output_dir)/ocware_stub
+	rm -fr $(output_dir)/*

--- a/firmware/host/Makefile
+++ b/firmware/host/Makefile
@@ -18,7 +18,7 @@ default:
 all:	ocmw_uart ocmw_usb ocmw_eth occli ocmw_eth_stub ocware_stub hash
 
 hash:
-	cd ../utilities/checksums; ./hosthash.sh $(shell pwd)/$(output_dir)
+	cd ../utilities/checksums; ./hashes.sh $(shell pwd)/$(output_dir) -host
 
 .PHONY:	occli
 

--- a/firmware/host/include/logger.h
+++ b/firmware/host/include/logger.h
@@ -49,11 +49,11 @@
  * @param ident an input value (by pointer)
  *
  */
-void initlog(const char* ident);
+extern void initlog(const char* ident);
 /*
  * deinitialize the logging routine
  *
  */
-void deinitlog(void);
+extern void deinitlog(void);
 
 #endif /* __LOGGER_H__ */

--- a/firmware/host/include/occli_common.h
+++ b/firmware/host/include/occli_common.h
@@ -31,7 +31,7 @@ typedef struct {
     char option;
     int sizeNum;
     int totalStr;
-}OCCLI_ARRAY_PARAM;
+} OCCLI_ARRAY_PARAM;
 
 typedef struct {
         char subsystem[OCCLI_CHAR_ARRAY_SIZE];
@@ -39,16 +39,16 @@ typedef struct {
         char subcomponent[OCCLI_CHAR_ARRAY_SIZE];
         char msgtype[OCCLI_CHAR_ARRAY_SIZE];
         char parameter[OCCLI_CHAR_ARRAY_SIZE];
-}strMsgFrame;
+} strMsgFrame;
 
 typedef struct {
     int8_t subsystem;
     int8_t component;
     int8_t msgtype;
     int16_t parameter;
-}sMsgParam;
+} sMsgParam;
 
-typedef struct{
+typedef struct {
     char *subsystem;
     char *component;
     char *msgtype;
@@ -63,7 +63,7 @@ typedef struct {
         int32_t number;
         char name[OCCLI_CHAR_ARRAY_SIZE];
     } Info[OCCLI_CHAR_ARRAY_SIZE];
-}subSystemInfo;
+} subSystemInfo;
 
 //Help Menu structure
 typedef struct {
@@ -74,43 +74,43 @@ typedef struct {
     char actionType[OCMW_MAX_ACTION_SIZE];
     char arguments[OCMW_HELP_FRAME_SIZE];
     char parameter[OCMW_HELP_FRAME_SIZE];
-}helpMenu;
+} helpMenu;
 
 typedef struct {
     char subsystem[OCCLI_CHAR_ARRAY_SIZE];
     char component[OCCLI_CHAR_ARRAY_SIZE];
     char subComponent[OCCLI_CHAR_ARRAY_SIZE];
-}commandFrame;
-/*
+} commandFrame;
 
+/*
  * Initialize the ocmw communication
  */
-int32_t occli_init_comm(void);
+extern int32_t occli_init_comm(void);
 /*
  * Deinitialize the ocmw communication
  */
-int8_t occli_deinit_comm(void);
+extern int8_t occli_deinit_comm(void);
 /*
  * @param cmd an input string (by pointer)
  * @param cmdlen an input value (by value)
  *
  * @return true if function succeeds, false otherwise
  */
-int32_t occli_send_cmd_to_ocmw(const char *cmd, int32_t cmdlen);
+extern int32_t occli_send_cmd_to_ocmw(const char *cmd, int32_t cmdlen);
 /*
  * @param resp an output value (by pointer)
  * @param resplen an output value (by value)
  *
  * @return true if function succeeds, false otherwise
  */
-int32_t occli_recv_cmd_resp_from_ocmw(char *resp, int32_t resplen);
+extern int32_t occli_recv_cmd_resp_from_ocmw(char *resp, int32_t resplen);
 /*
  * @param resp an output value (by pointer)
  * @param resplen an output value (by value)
  *
  * @return true if function succeeds, false otherwise
  */
-int32_t occli_recv_alertmsg_from_ocmw(char *resp, int32_t resplen);
+extern int32_t occli_recv_alertmsg_from_ocmw(char *resp, int32_t resplen);
 /*
  * @param  root an input value (by pointer)
  * @param  msgFrame an input value (by pointer)
@@ -119,8 +119,10 @@ int32_t occli_recv_alertmsg_from_ocmw(char *resp, int32_t resplen);
  *
  * @return true if function succeeds, false otherwise
  */
-int32_t ocmw_parse_msgframe(const Component *root, strMsgFrame *msgFrame,
-                    uint8_t actiontype,ocmwSchemaSendBuf *ecSendBuf);
+extern int32_t ocmw_parse_msgframe(const Component *root,
+                                   strMsgFrame *msgFrame,
+                                   uint8_t actiontype,
+                                   ocmwSchemaSendBuf *ecSendBuf);
 /*
  * @param root an output value (by pointer)
  * @param dMsgFrameParam an output value (by pointer)
@@ -128,9 +130,9 @@ int32_t ocmw_parse_msgframe(const Component *root, strMsgFrame *msgFrame,
  *
  * @return true if function succeeds, false otherwise
  */
-void ocmw_deserialization_msgframe(const Component *root,
-                    sMsgParam *dMsgFrameParam,
-                    OCMPMessageFrame *ecReceivedMsg);
+extern void ocmw_deserialization_msgframe(const Component *root,
+                                          sMsgParam *dMsgFrameParam,
+                                          OCMPMessageFrame *ecReceivedMsg);
 /*
  * @param compBase an output value (by pointer)
  * @param msgFrame an output value (by pointer)
@@ -139,9 +141,10 @@ void ocmw_deserialization_msgframe(const Component *root,
  *
  * @return true if function succeeds, false otherwise
  */
-int32_t ocmw_parse_command_msgframe(const Component *compBase,
-                    strMsgFrame *msgFrame, uint8_t actiontype,
-                    ocmwSchemaSendBuf *ecSendBuf);
+extern int32_t ocmw_parse_command_msgframe(const Component *compBase,
+                                           strMsgFrame *msgFrame,
+                                           uint8_t actiontype,
+                                           ocmwSchemaSendBuf *ecSendBuf);
 /*
  * @param compBase an output value (by pointer)
  * @param msgFrame an output value (by pointer)
@@ -150,17 +153,18 @@ int32_t ocmw_parse_command_msgframe(const Component *compBase,
  *
  * @return true if function succeeds, false otherwise
  */
-int32_t ocmw_parse_post_msgframe(const Component *compBase,
-                    strMsgFrame *msgFrame, uint8_t actiontype,
-                    ocmwSchemaSendBuf *ecSendBuf);
+extern int32_t ocmw_parse_post_msgframe(const Component *compBase,
+                                        strMsgFrame *msgFrame,
+                                        uint8_t actiontype,
+                                        ocmwSchemaSendBuf *ecSendBuf);
 /*
  * @param root an output value (by pointer)
  * @param systemInfo an output value (by pointer)
  *
  * @return true if function succeeds, false otherwise
  */
-int32_t ocmw_frame_subsystem_from_schema(const Component *root,
-                    subSystemInfo *systemInfo);
+extern int32_t ocmw_frame_subsystem_from_schema(const Component *root,
+                                                subSystemInfo *systemInfo);
 
 /*
  * @param root an output value (by pointer)
@@ -168,23 +172,23 @@ int32_t ocmw_frame_subsystem_from_schema(const Component *root,
  *
  * @return true if function succeeds, false otherwise
  */
-int32_t ocmw_frame_postTable_from_schema(const Component *root);
+extern int32_t ocmw_frame_postTable_from_schema(const Component *root);
 
 /*
  * @param pointer to global memory
  *
  * @return  NONE
  */
-extern inline void ocmw_free_global_pointer(void **ptr);
+extern void ocmw_free_global_pointer(void **ptr);
 /*
  * @param root an output value (by pointer)
  * @param systemInfo an output value (by pointer)
  *
  * @return true if function succeeds, false otherwise
  */
-int8_t occli_printHelpMenu(const Component *root,char *cmd);
+extern int8_t occli_printHelpMenu(const Component *root,char *cmd);
 
 /*Display CLI window*/
-void occli_print_opencelluar();
+extern void occli_print_opencelluar();
 
 #endif /* _OCCLI_COMM_H_ */

--- a/firmware/host/include/ocmw_core.h
+++ b/firmware/host/include/ocmw_core.h
@@ -22,7 +22,7 @@ sem_t semCommandPost;
 #define OCMW_TIMED_WAIT_INDEX       1
 #define PARAM_STR_MAX_BUFF_SIZE     100
 
-int32_t ocmw_init();
+extern int32_t ocmw_init();
 /*
  * @param actionType an input enum value (by value)
  * @param msgType an input enum value (by value)
@@ -32,37 +32,37 @@ int32_t ocmw_init();
  *
  * @return true if function succeeds, false otherwise
  */
-int32_t ocmw_msg_packetize_and_send(char * argv[], uint8_t actionType,
+extern int32_t ocmw_msg_packetize_and_send(char * argv[], uint8_t actionType,
         uint8_t msgType, const int8_t * paramStr, uint8_t interface,
         void* paramVal);
 /*
  * Message parser module
  *
  */
-void ocmw_ec_msgparser(void);
+extern void ocmw_ec_msgparser(void);
 /*
  * Thread to parse the data coming from EC to AP through uart
  * @param pthreadData an input value (by pointer)
  */
-void * ocmw_thread_uartmsgparser(void *pthreadData);
+extern void * ocmw_thread_uartmsgparser(void *pthreadData);
 
 /*
  * Thread to parse the data coming from EC to AP through ethernet
  * @param pthreadData an input value (by pointer)
  */
-void * ocmw_thread_ethmsgparser(void *pthreadData);
+extern void * ocmw_thread_ethmsgparser(void *pthreadData);
 /*
  * @param ecMsgFrame an input structure (by value)
  * @param interface an input enum value (by value)
  *
  * @return true if function succeeds, false otherwise
  */
-int32_t ocmw_send_msg(OCMPMessageFrame ecMsgFrame, uint8_t interface);
+extern int32_t ocmw_send_msg(OCMPMessageFrame ecMsgFrame, uint8_t interface);
 /*
  * @param semId an input value (by pointer)
  * @param semWaitType an input value (by value)
  *
  * @return true if function succeeds, false otherwise
  */
-int32_t ocmw_sem_wait(sem_t *semId, int32_t semWaitType);
+extern int32_t ocmw_sem_wait(sem_t *semId, int32_t semWaitType);
 #endif /* _OCMW_CORE_H_ */

--- a/firmware/host/include/ocmw_eth_comm.h
+++ b/firmware/host/include/ocmw_eth_comm.h
@@ -30,26 +30,25 @@
  *
  * @return true if function succeeds, false otherwise
  */
-int32_t ocmw_init_eth_comm(int32_t sentDev);
+extern int32_t ocmw_init_eth_comm(int32_t sentDev);
 /*
  * Deinitialize the ocmw ethernet communication
  *
  * @return true if function succeeds, false otherwise
  */
-int32_t ocmw_deinit_eth_comm(int32_t sentDev);
+extern int32_t ocmw_deinit_eth_comm(int32_t sentDev);
 /*
  * @param cmd an input string (by pointer)
  * @param cmdlen an input value (by value)
  *
  * @return true if function succeeds, false otherwise
  */
-int32_t ocmw_send_eth_msgto_ec(const int8_t *cmd, int32_t cmdlen,int32_t sentDev);
+extern int32_t ocmw_send_eth_msgto_ec(const int8_t *cmd, int32_t cmdlen,int32_t sentDev);
 /*
  * @param resp an input value (by pointer)
  * @param resplen an input value (by value)
  *
  * @return true if function succeeds, false otherwise
  */
-int32_t ocmw_recv_eth_msgfrom_ec(int8_t *resp, int32_t resplen, int32_t sentDev);
-
+extern int32_t ocmw_recv_eth_msgfrom_ec(int8_t *resp, int32_t resplen, int32_t sentDev);
 #endif /* _OCCLI_IPC_COMM_H_ */

--- a/firmware/host/include/ocmw_helper.h
+++ b/firmware/host/include/ocmw_helper.h
@@ -104,7 +104,7 @@ typedef struct __attribute__((packed, aligned(1))){
     char subsysName[OCMW_MAX_SUBSYSTEM_SIZE];   /* Subsystem Name */
     char deviceName[OCMW_POST_DEVICE_SIZE];     /* Device Name */
     uint8_t status;                         /* device status */
-}ocwarePostResultData;
+} ocwarePostResultData;
 
 typedef struct {
     unsigned int count;                                         /* Device Status count */
@@ -122,14 +122,14 @@ typedef struct {
  *
  * @return true if function succeeds, false otherwise
  */
-int32_t ocmw_sem_wait_nointr(sem_t *sem);
+extern int32_t ocmw_sem_wait_nointr(sem_t *sem);
 /*
  * @param sem an input value (by pointer)
  * @param timeout an input value (by pointer)
  *
  * @return true if function succeeds, false otherwise
  */
-int32_t ocmw_sem_timedwait_nointr(sem_t *sem, const struct timespec *timeout);
+extern int32_t ocmw_sem_timedwait_nointr(sem_t *sem, const struct timespec *timeout);
 /*
  * @param paramindex an input value (by value)
  * @param paramSizebuf an input value (by pointer)
@@ -137,47 +137,37 @@ int32_t ocmw_sem_timedwait_nointr(sem_t *sem, const struct timespec *timeout);
  * @param pos an output value (by pointer)
  *
  */
-void ocmw_dataparsing_from_db(int32_t paramIndex, int32_t *paramSizebuf,
+extern void ocmw_dataparsing_from_db(int32_t paramIndex, int32_t *paramSizebuf,
         int32_t *dataSize, int32_t *pos);
 /*
  * @param input an input buffer (by pointer)
  * @param bufParamStruct an output buffer (by pointer)
  *
  */
-void ocmw_dataparsing_from_ec(ocmwSendRecvBuf *input,
+extern void ocmw_dataparsing_from_ec(ocmwSendRecvBuf *input,
         bufParam * bufParamStruct);
 /*
  * @param uartInputBuf an input buffer (by pointer)
  *
  * @return true if function succeeds, false otherwise
  */
-int32_t ocmw_fill_inputstruct(ocmwSendRecvBuf *uartInputBuf);
+extern int32_t ocmw_fill_inputstruct(ocmwSendRecvBuf *uartInputBuf);
 /*
  * @param ecInputData an input data (by value)
  *
  * @return true if function succeeds, false otherwise
  */
-int8_t ocmw_parse_eepromdata_from_ec (ocmwSendRecvBuf ecInputData);
+extern int8_t ocmw_parse_eepromdata_from_ec (ocmwSendRecvBuf ecInputData);
 /*
  * @param ecInputData an input data (by value)
  *
  * @return true if function succeeds, false otherwise
  */
-int32_t ocmw_parse_obc_from_ec(ocmwSendRecvBuf ecInputData);
+extern int32_t ocmw_parse_obc_from_ec(ocmwSendRecvBuf ecInputData);
 /*
  * @param ecInputData an input data (by value)
  *
  * @return true if function succeeds, false otherwise
  */
-int32_t ocmw_parse_testingmodule_from_ec(ocmwSendRecvBuf ecInputData);
-/*
- * @param msgaction an input value (by value)
- * @param msgtype an input value (by value)
- * @param paramstr an input string (by pointer)
- * @param paramvalue an input value (by pointer)
- *
- */
-//int ocmw_msgproc_send_msg(int8_t msgaction, int8_t msgtype,
-    //                    const int8_t* paramstr, void* paramvalue);
-
+extern int32_t ocmw_parse_testingmodule_from_ec(ocmwSendRecvBuf ecInputData);
 #endif /* _OCMW_HELPER_H_ */

--- a/firmware/host/include/ocmw_msgproc.h
+++ b/firmware/host/include/ocmw_msgproc.h
@@ -11,7 +11,7 @@
 
 #include "ocmp_frame.h"
 
-int ocmw_msgproc_send_msg(char * argv[], uint8_t action, int8_t msgtype,
-                        const int8_t* paramstr, void* paramvalue);
+extern int ocmw_msgproc_send_msg(char * argv[], uint8_t action, int8_t msgtype,
+                                 const int8_t* paramstr, void* paramvalue);
 
 #endif /* _OCMW_MSGPROC_H_ */

--- a/firmware/host/include/ocmw_occli_comm.h
+++ b/firmware/host/include/ocmw_occli_comm.h
@@ -23,19 +23,19 @@
 typedef struct {
     int8_t pin;
     int8_t value;
-}debugGPIOData;
+} debugGPIOData;
 
 typedef struct {
     uint16_t regAddress;
     uint16_t regValue;
-}debugMDIOData;
+} debugMDIOData;
 
 typedef struct  __attribute__((packed, aligned(1))){
     uint8_t slaveAddress;
     uint8_t numOfBytes;
     uint8_t regAddress;
     uint16_t regValue;
-}debugI2CData;
+} debugI2CData;
 
 typedef enum {
     SET_STR,
@@ -71,58 +71,58 @@ typedef enum {
  *
  * @return true if function succeeds, false otherwise
  */
-int32_t ocmw_init_occli_comm(void);
+extern int32_t ocmw_init_occli_comm(void);
 
 /*
  * Deinitialize the ocmw cli communication
  *
  * @return true if function succeeds, false otherwise
  */
-int32_t ocmw_deinit_occli_comm(void);
+extern int32_t ocmw_deinit_occli_comm(void);
 /*
  * @param cmd an input string (by pointer)
  * @param cmdlen an input value (by value)
  *
  * @return true if function succeeds, false otherwise
  */
-int32_t ocmw_recv_clicmd_from_occli(char* cmdstr, int32_t cmdlen);
+extern int32_t ocmw_recv_clicmd_from_occli(char* cmdstr, int32_t cmdlen);
 /*
  * @param resp an input value (by pointer)
  * @param resplen an input value (by value)
  *
  * @return true if function succeeds, false otherwise
  */
-int32_t ocmw_send_clicmd_resp_to_occli(const char* resp, int32_t resplen);
+extern int32_t ocmw_send_clicmd_resp_to_occli(const char* resp, int32_t resplen);
 /*
  * @param cmdstr an input value (by pointer)
  * @param response an output value (by pointer)
  *
  * @return true if function succeeds, false otherwise
  */
-int ocmw_clicmd_handler(const char *cmdstr, char *response);
+extern int ocmw_clicmd_handler(const char *cmdstr, char *response);
 /*
  * Initialize the ocmw alert communication
  *
  * @return true if function succeeds, false otherwise
  */
-int32_t init_occli_alert_comm();
+extern int32_t init_occli_alert_comm();
 /*
  * Deinitialize the ocmw alert communication
  *
  * @return true if function succeeds, false otherwise
  */
-int32_t ocmw_deinit_occli_alert_comm(void);
+extern int32_t ocmw_deinit_occli_alert_comm(void);
 /*
  * @param buf an input value (by pointer)
  * @param buflen an input value (by value)
  *
  * @return true if function succeeds, false otherwise
  */
-int32_t ocmw_send_alert_to_occli(const char* buf, int32_t buflen);
+extern int32_t ocmw_send_alert_to_occli(const char* buf, int32_t buflen);
 
-char ocmw_retrieve_post_results_count(ocwarePostResults *psData);
+extern char ocmw_retrieve_post_results_count(ocwarePostResults *psData);
 
-char ocmw_retrieve_post_results(ocwarePostResults *psData);
+extern char ocmw_retrieve_post_results(ocwarePostResults *psData);
 
-char ocmw_retrieve_reply_code_desc(ocwarePostReplyCode *replyCode);
+extern char ocmw_retrieve_reply_code_desc(ocwarePostReplyCode *replyCode);
 #endif /* _OCMW_IPC_COMM_H_ */

--- a/firmware/host/include/ocmw_schema.h
+++ b/firmware/host/include/ocmw_schema.h
@@ -40,13 +40,12 @@ typedef enum ErrorSource {
   ERR_RC_INTERNAL = 0,
   ERR_SRC_CMS = 1,
   ERR_SRC_CME = 2
-}Source;
+} Source;
 
 typedef enum OperatorStat {
     TWOG_SIM_STAT_UNKNOWN = 0x00,
     TWOG_SIM_STAT_AVAILABLE = 0x01,
     TWOG_SIM_STAT_CURRENT = 0x02,
     TWOG_SIM_STAT_FORBIDDEN = 0x03,
-}eOperatorStat;
+} eOperatorStat;
 #endif /* _OCMW_SCHEMA_H_ */
-

--- a/firmware/host/include/ocmw_uart_comm.h
+++ b/firmware/host/include/ocmw_uart_comm.h
@@ -29,31 +29,31 @@ typedef void
  * @param msgsize an input value (by value)
  *
  */
-void ocmw_ec_uart_msg_hndlr(const unsigned char* msgstr, int32_t msgsize);
+extern void ocmw_ec_uart_msg_hndlr(const unsigned char* msgstr, int32_t msgsize);
 /*
  * Initialize the ocmw ec communication
  *
  * @return true if function succeeds, false otherwise
  */
-int32_t ocmw_init_ec_comm(handle_msg_from_ec_t msghndlr);
+extern int32_t ocmw_init_ec_comm(handle_msg_from_ec_t msghndlr);
 /*
  * Deinitialize the ocmw ec communication
  *
  * @return true if function succeeds, false otherwise
  */
-int32_t ocmw_deinit_ec_comm(void);
+extern int32_t ocmw_deinit_ec_comm(void);
 /*
  * @param msgstr an input value (by pointer)
  * @param size an input value (by value)
  *
  * @return true if function succeeds, false otherwise
  */
-int32_t ocmw_send_uart_msg_to_ec(const uint8_t* msgstr, int32_t size);
+extern int32_t ocmw_send_uart_msg_to_ec(const uint8_t* msgstr, int32_t size);
 /*
  * @param pathName an input value (by pointer)
  *
  * @return true if function succeeds, false otherwise
  */
-int32_t ocmw_find_ttyacm_port(char *pathName);
+extern int32_t ocmw_find_ttyacm_port(char *pathName);
 
 #endif /* _OCMW_UART_COMM_H_ */

--- a/firmware/host/include/ocware_stub_main_module.h
+++ b/firmware/host/include/ocware_stub_main_module.h
@@ -71,13 +71,13 @@ typedef struct {
     uint8_t paramPos;
     uint8_t datatype;
     void *data;
-}OCWareStubDatabase;
+} OCWareStubDatabase;
 
 typedef struct{
     uint8_t SubsystemId;
     uint8_t DeviceNumber;
     ePostCode Status;
-}OCWareStubPostData;
+} OCWareStubPostData;
 
 typedef enum {
     OCSTUB_VALUE_ZERO,
@@ -92,29 +92,29 @@ typedef enum {
     OCSTUB_VALUE_TYPE_I2C_DEBUG,
     OCSTUB_VALUE_TYPE_GPIO_DEBUG,
     OCSTUB_VALUE_TYPE_MDIO_DEBUG,
-}OCWareStubsizeflag;
+} OCWareStubsizeflag;
 
 typedef struct {
     uint8_t slaveAddress;
     uint8_t numOfBytes;
     uint8_t regAddress;
     uint16_t regValue;
-}OCWareDebugI2Cinfo;
+} OCWareDebugI2Cinfo;
 
 typedef struct {
     uint16_t regAddress;
     uint16_t regValue;
-}OCWareDebugMDIOinfo;
+} OCWareDebugMDIOinfo;
 
 typedef struct {
     uint8_t pin_nbr;
     uint8_t value;
-}OCWareDebugGPIOinfo;
+} OCWareDebugGPIOinfo;
 
 typedef enum ocware_ret{
 	STUB_FAILED = -1,
 	STUB_SUCCESS = 0
-}ocware_stub_ret;
+} ocware_stub_ret;
 
 
 extern int8_t debugGetCommand;
@@ -131,7 +131,7 @@ extern int8_t PostEnable;
  * @return STUB_SUCCESS - for success
  *         STUB_FAILED  - for failure
  ******************************************************************************/
-ocware_stub_ret ocware_stub_parse_post_get_message(char *buffer);
+extern ocware_stub_ret ocware_stub_parse_post_get_message(char *buffer);
 
 /******************************************************************************
  * Function Name    : ocware_stub_parse_command_message
@@ -142,7 +142,7 @@ ocware_stub_ret ocware_stub_parse_post_get_message(char *buffer);
  * @return STUB_SUCCESS - for success
  *         STUB_FAILED  - for failure
  ******************************************************************************/
-ocware_stub_ret ocware_stub_parse_command_message(char *buffer);
+extern ocware_stub_ret ocware_stub_parse_command_message(char *buffer);
 
 /******************************************************************************
  * Function Name    : ocware_stub_get_set_params
@@ -154,7 +154,7 @@ ocware_stub_ret ocware_stub_parse_command_message(char *buffer);
  * @return STUB_SUCCESS - for success
  *         STUB_FAILED  - for failure
  ******************************************************************************/
-ocware_stub_ret ocware_stub_get_set_params(OCMPMessage *msgFrameData);
+extern ocware_stub_ret ocware_stub_get_set_params(OCMPMessage *msgFrameData);
 /******************************************************************************
  * Function Name    : ocware_stub_init_database
  * Description      : Parse the schema and add entries in the DB
@@ -162,7 +162,7 @@ ocware_stub_ret ocware_stub_get_set_params(OCMPMessage *msgFrameData);
  * @return STUB_SUCCESS - for success
  *         STUB_FAILED  - for failure
  ******************************************************************************/
-ocware_stub_ret ocware_stub_init_database(void);
+extern ocware_stub_ret ocware_stub_init_database(void);
 /******************************************************************************
  * Function Name    : ocware_stub_send_msgframe_middleware
  * Description      : send message to the MW
@@ -173,7 +173,7 @@ ocware_stub_ret ocware_stub_init_database(void);
  * @return STUB_SUCCESS - for success
  *         STUB_FAILED  - for failure
  ******************************************************************************/
-ocware_stub_ret ocware_stub_send_msgframe_middleware(char **buffer, int32_t bufferlen);
+extern ocware_stub_ret ocware_stub_send_msgframe_middleware(char **buffer, int32_t bufferlen);
 /******************************************************************************
  * Function Name    : ocware_stub_init_ethernet_comm
  * Description      : initialise the socket IPC
@@ -181,7 +181,7 @@ ocware_stub_ret ocware_stub_send_msgframe_middleware(char **buffer, int32_t buff
  * @return STUB_SUCCESS - for success
  *         STUB_FAILED  - for failure
  ******************************************************************************/
-ocware_stub_ret ocware_stub_init_ethernet_comm(void);
+extern ocware_stub_ret ocware_stub_init_ethernet_comm(void);
 /******************************************************************************
  * Function Name    : ocware_stub_deinit_ethernet_comm
  * Description      : close the IPC socket
@@ -189,7 +189,7 @@ ocware_stub_ret ocware_stub_init_ethernet_comm(void);
  * @return STUB_SUCCESS - for success
  *         STUB_FAILED  - for failure
  ******************************************************************************/
-ocware_stub_ret ocware_stub_deinit_ethernet_comm();
+extern ocware_stub_ret ocware_stub_deinit_ethernet_comm();
 /******************************************************************************
  * Function Name    : ocware_stub_recv_msgfrom_middleware
  * Description      : Receive message from MW
@@ -201,7 +201,7 @@ ocware_stub_ret ocware_stub_deinit_ethernet_comm();
  * @return STUB_SUCCESS - for success
  *         STUB_FAILED  - for failure
  ******************************************************************************/
-ocware_stub_ret ocware_stub_recv_msgfrom_middleware(char **buffer, int32_t bufferlen);
+extern ocware_stub_ret ocware_stub_recv_msgfrom_middleware(char **buffer, int32_t bufferlen);
 /******************************************************************************
  * Function Name    : ocware_stub_get_database
  * Description      : Function to retrieve data from the DB
@@ -212,7 +212,7 @@ ocware_stub_ret ocware_stub_recv_msgfrom_middleware(char **buffer, int32_t buffe
  * @return STUB_SUCCESS - for success
  *         STUB_FAILED  - for failure
  ******************************************************************************/
-ocware_stub_ret ocware_stub_get_database(OCMPMessage *msgFrameData);
+extern ocware_stub_ret ocware_stub_get_database(OCMPMessage *msgFrameData);
 /******************************************************************************
  * Function Name    : ocware_stub_set_database
  * Description      : Function to modify data in the DB
@@ -223,7 +223,7 @@ ocware_stub_ret ocware_stub_get_database(OCMPMessage *msgFrameData);
  * @return STUB_SUCCESS - for success
  *         STUB_FAILED  - for failure
  ******************************************************************************/
-ocware_stub_ret ocware_stub_set_database(OCMPMessage *msgFrameData);
+extern ocware_stub_ret ocware_stub_set_database(OCMPMessage *msgFrameData);
 /******************************************************************************
  * Function Name    : ocware_stub_get_post_result_paramvalue_from_table
  * Description      : Fill payload with the post information
@@ -234,7 +234,7 @@ ocware_stub_ret ocware_stub_set_database(OCMPMessage *msgFrameData);
  * @return STUB_SUCCESS - for success
  *         STUB_FAILED  - for failure
  ******************************************************************************/
-ocware_stub_ret ocware_stub_get_post_result_paramvalue_from_table(
+extern ocware_stub_ret ocware_stub_get_post_result_paramvalue_from_table(
         OCMPMessage *msgFrameData,
         int8_t *payload);
 /******************************************************************************
@@ -247,7 +247,7 @@ ocware_stub_ret ocware_stub_get_post_result_paramvalue_from_table(
  * @return STUB_SUCCESS - for success
  *         STUB_FAILED  - for failure
  ******************************************************************************/
-ocware_stub_ret ocware_stub_parse_debug_actiontype(OCMPMessage *msgFrameData);
+extern ocware_stub_ret ocware_stub_parse_debug_actiontype(OCMPMessage *msgFrameData);
 /******************************************************************************
  * Function Name    :  ocware_stub_get_post_database
  * Description      :  extract device number and status from the post database
@@ -260,7 +260,7 @@ ocware_stub_ret ocware_stub_parse_debug_actiontype(OCMPMessage *msgFrameData);
  * @return STUB_SUCCESS - for success
  *         STUB_FAILED  - for failure
  ******************************************************************************/
-ocware_stub_ret ocware_stub_get_post_database(OCMPMessage *msgFrameData,
-                                              char *payload);
+extern ocware_stub_ret ocware_stub_get_post_database(OCMPMessage *msgFrameData,
+                                                     char *payload);
 
 #endif /* __OCMW_STUB_H__ */

--- a/firmware/host/include/ocwdg_daemon.h
+++ b/firmware/host/include/ocwdg_daemon.h
@@ -20,11 +20,11 @@ sem_t semEcWdgMsg;
  *
  * @return true if function succeeds, false otherwise
  */
-int32_t ocwdg_init(void);
+extern int32_t ocwdg_init(void);
 /*
  * @param pthreadData an input value (by pointer)
  *
  */
-void * ocwdg_thread_comm_with_ec(void *pthreadData);
+extern void * ocwdg_thread_comm_with_ec(void *pthreadData);
 
 #endif /* _OCWGD_DAEMON_H_ */

--- a/firmware/host/include/util.h
+++ b/firmware/host/include/util.h
@@ -14,6 +14,6 @@
  * @param buflen an input value (by value)
  *
  */
-void hexdisp(const unsigned char* buf, int buflen);
+extern void hexdisp(const unsigned char* buf, int buflen);
 
 #endif /* _UTIL_H_ */

--- a/firmware/host/occli/occli_helpMenu.c
+++ b/firmware/host/occli/occli_helpMenu.c
@@ -297,7 +297,7 @@ void occli_printHelpMenu_on_console(helpMenu *helpMenuArray[],
  * Input(s)         : helpMenuArray
  * Output(s)        : helpMenuArray
  ***************************************************************************/
-inline void occli_free_helpMenupointer(helpMenu *helpMenuArray[])
+static void occli_free_helpMenupointer(helpMenu *helpMenuArray[])
 {
     int32_t mallocIndex = 0;
 

--- a/firmware/host/ocmw/ocmw_clicmd.c
+++ b/firmware/host/ocmw/ocmw_clicmd.c
@@ -816,7 +816,7 @@ static int32_t ocmw_handle_post_command(char* strTokenArray[], char *response)
  * Input(s)         : strTokenArray
  * Output(s)        : strTokenArray
  ***************************************************************************/
-inline void ocmw_free_pointer(char **strTokenArray) {
+static void ocmw_free_pointer(char **strTokenArray) {
     if (strTokenArray) {
         free(strTokenArray);
     }

--- a/firmware/host/ocmw/ocmw_core.c
+++ b/firmware/host/ocmw/ocmw_core.c
@@ -51,7 +51,7 @@ ocwarePostReplyCode ocmwReplyCode[] = {
  * Input(s)         : ptr
  * Output(s)        :
 ******************************************************************************/
-inline void ocmw_free_global_pointer(void **ptr)
+void ocmw_free_global_pointer(void **ptr)
 {
     if(*ptr != NULL) {
         free(*ptr);

--- a/firmware/utilities/checksums/hashes.sh
+++ b/firmware/utilities/checksums/hashes.sh
@@ -1,0 +1,15 @@
+#!/bin/sh -e
+#
+# Description
+#   This script records the md5 hashes of host build objects
+#
+BIN_FILES=$(find $1 -executable -type f)
+if [ "$2" = "-host" ]; then
+  MD5_FILE="hmd5sums.txt"
+fi
+
+if [ "$2" = "-ec" ]; then
+  MD5_FILE="ecmd5sums.txt"
+fi
+
+md5sum $BIN_FILES > $MD5_FILE

--- a/firmware/utilities/checksums/hashes.sh
+++ b/firmware/utilities/checksums/hashes.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 #
 # Description
-#   This script records the md5 hashes of host build objects
+#   This script records the md5 hashes of build objects
 #
 BIN_FILES=$(find $1 -executable -type f)
 if [ "$2" = "-host" ]; then

--- a/firmware/utilities/checksums/hosthash.sh
+++ b/firmware/utilities/checksums/hosthash.sh
@@ -1,8 +1,0 @@
-#!/bin/sh -e
-#
-# Description
-#   This script records the md5 hashes of host build objects
-#
-BIN_FILES=$(find $1 -executable -type f)
-HOST_MD5_FILE="hmd5sums.txt"
-md5sum $BIN_FILES > $HOST_MD5_FILE

--- a/firmware/utilities/checksums/hosthash.sh
+++ b/firmware/utilities/checksums/hosthash.sh
@@ -1,0 +1,8 @@
+#!/bin/sh -e
+#
+# Description
+#   This script records the md5 hashes of host build objects
+#
+BIN_FILES=$(find $1 -executable -type f)
+HOST_MD5_FILE="hmd5sums.txt"
+md5sum $BIN_FILES > $HOST_MD5_FILE


### PR DESCRIPTION
## Summary
With all warnings treated as errors, gcc 7.3 fails to build host.  Removed cause for warnings to allow build.

## Test Plan
Build from firmware/host with gcc 7.3 and older (v 4.8).  In both cases, test in HW.

## Issues
Fixes Issue #200 
Fixes Issue #206 