### PR TITLE
Fixing GCC Makefile issue that .bin file would not boot after flash. 

### DIFF
--- a/firmware/ec/Makefile
+++ b/firmware/ec/Makefile
@@ -97,7 +97,7 @@ hash:
 oc_connect1: $(OUT)/OpenCellular.bin
 
 $(OUT)/%/compiler.opt $(OUT)/%/linker.cmd : %.cfg
-	$(CONFIGURO) -c $(TOOLCHAIN) -t $(TARGET) -p $(PLATFORM) -r release $<
+	$(CONFIGURO) -c $(TOOLCHAIN) -t $(TARGET) -p $(PLATFORM) -r debug $<
 	cp $(OUT)/$(CONFIG)/package/cfg/$*_$(ROV_XS_SUFFIX).rov.xs .
 
 $(MAIN_OBJS): %.o: %.c $(OUT)/$(CONFIG)/compiler.opt


### PR DESCRIPTION
## Summary
GCC Built bin would not boot after being flashed to GBCv1. I had changed debug to release on the xdc build step and not verified that change on the makefile pull request, and apparently that breaks the bootup somehow. For now, reverting it back to debug and will look into getting release to work in the future. 

## Test Plan
Build master version, flash to hardware using lm flasher, reboot board and verify it comes up. 

## Issues

