### PR TITLE
memory opt for Linux build signed

### DIFF
--- a/firmware/ec/Makefile
+++ b/firmware/ec/Makefile
@@ -64,7 +64,7 @@ CFLAGS += -isystem$(XDC_PATH) -isystem$(BIOS_PATH) -isystem$(TIDRIVER_PATH) -isy
 
 LD = $(TOOLCHAIN)/bin/arm-none-eabi-gcc
 LFLAGS = -nostartfiles -static -Wl,--gc-sections -march=armv7e-m -Wl,-T,OC_CONNECT1.lds
-LFLAGS += --specs=nosys.specs -mfloat-abi=hard -mfpu=fpv4-sp-d16
+LFLAGS += --specs=nosys.specs --specs=nano.specs -mfloat-abi=hard -mfpu=fpv4-sp-d16
 LFLAGS += -Wl,--print-memory-usage #Optional
 LFLAGS += -Xlinker -Map=$(OUT)/main.map #Optional
 LLIBS = -L$(TIVAWARE_DIR)/driverlib/gcc/

--- a/firmware/ec/src/interfaces/UART/uartdma.c
+++ b/firmware/ec/src/interfaces/UART/uartdma.c
@@ -45,10 +45,10 @@ Queue_Handle uartTxMsgQueue;
 
 /* Global Task Configuration Variables */
 Task_Struct ocUARTDMATask;
-Char ocUARTDMATaskStack[OCUARTDMA_TASK_STACK_SIZE];
+static Char ocUARTDMATaskStack[OCUARTDMA_TASK_STACK_SIZE];
 
 Task_Struct ocUARTDMATxTask;
-Char ocUARTDMATxTaskStack[OCUARTDMATX_TASK_STACK_SIZE];
+static Char ocUARTDMATxTaskStack[OCUARTDMATX_TASK_STACK_SIZE];
 
 /*****************************************************************************
  * The transmit and receive buffers used for the UART transfers.  There is one
@@ -70,7 +70,7 @@ static uint8_t ui8uartdmaRxBuf[UART_RXBUF_SIZE];
 #elif defined(__GNUC__)
 __attribute__((aligned(1024)))
 #endif
-uint8_t pui8ControlTable[1024];
+static uint8_t pui8ControlTable[1024];
 
 /*****************************************************************************
  *


### PR DESCRIPTION
## Summary
Pl Note: The earlier commit was not signed for the pull request #216 hence raising a new pull request with the same file changes.
There is a significant difference in the memory map between the linker output of GCC and CCS for the same code base for GBCV1. Issue #204


## Test Plan
The memory occupied by .data, .bss symbols was verified as well the output of Makefile. Attached the build and test log of CCS and Linux image. After the optimization changes the code behavior was verified to be same as master branch. Attached logs.
[logs_204.zip](https://github.com/Telecominfraproject/OpenCellular/files/2737315/logs_204.zip)

## Issues
resolves #204


