### PR TITLE
UT for ocmp_debugocgpio

### DIFF
--- a/firmware/ec/src/devices/ocmp_wrappers/ocmp_debugocgpio.c
+++ b/firmware/ec/src/devices/ocmp_wrappers/ocmp_debugocgpio.c
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-#include "inc/ocmp_wrappers/ocmp_debugocgpio.h"
+#include "common/inc/ocmp_wrappers/ocmp_debugocgpio.h"
 
 #include "common/inc/global/Framework.h"
 #include "common/inc/global/ocmp_frame.h"
@@ -51,12 +51,11 @@ bool ocgpio_get(void *gpio_cfg, void *oc_gpio)
                                OCGPIO_CFG_IN_PU) };
     ret = OcGpio_configure(&ocgpio, OCGPIO_CFG_INPUT);
     s_oc_gpio->value = OcGpio_read(&ocgpio);
-    if (s_oc_gpio->value < 0) {
-        ret = -1;
-    }
     return (ret == 0);
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 static ePostCode _probe(void *driver, POSTData *postData)
 {
     S_OCGPIO_Cfg *oc_gpio_cfg = (S_OCGPIO_Cfg *)driver;
@@ -73,6 +72,7 @@ static ePostCode _init(void *driver, const void *config,
     // Dummy functions.
     return POST_DEV_CFG_DONE;
 }
+#pragma GCC diagnostic pop
 
 const Driver_fxnTable DEBUG_OCGPIO_fxnTable = {
     /* Message handlers */

--- a/firmware/ec/test/Makefile
+++ b/firmware/ec/test/Makefile
@@ -41,7 +41,7 @@ CFLAGS += -Dxdc_target_types__="xdc_target_posix.h"
 # Short enums are assumed throughout the code, need the -fshort-enums flag
 CFLAGS += -fshort-enums
 
-INC_DIRS=-I. -Isrc -I$(UNITY_ROOT)/src -I$(OCWARE_ROOT) -I$(OCWARE_ROOT)/src -Ixdc_stubs -I$(DIR_SYSBIOS) -I$(DIR_TIDRIVERS) -I$(DIR_XDC)
+INC_DIRS=-I. -Isrc -isystem$(UNITY_ROOT)/src -I$(OCWARE_ROOT) -I$(OCWARE_ROOT)/src -Ixdc_stubs -isystem$(DIR_SYSBIOS) -isystem$(DIR_TIDRIVERS) -isystem$(DIR_XDC)
 
 BUILD_PATHS = $(RUNNER_PATH) $(PATHB) $(PATHR)
 

--- a/firmware/ec/test/Makefile
+++ b/firmware/ec/test/Makefile
@@ -190,6 +190,9 @@ $(PATHB)Test_ocmp_rfwatchdog$(TARGET_EXTENSION): $(STD_FILES) $(TEST_OCMP_RFWATC
 TEST_OCMP_FE_SRC=$(OCWARE_ROOT)/src/devices/ocmp_wrappers/ocmp_fe.c $(OCWARE_ROOT)/platform/oc-sdr/cfg/OC_CONNECT_FE.c
 $(PATHB)Test_ocmp_fe$(TARGET_EXTENSION): $(STD_FILES) $(TEST_OCMP_FE_SRC)
 
+TEST_OCMP_DEBUGOCGPIO_SRC=$(OCWARE_ROOT)/src/devices/ocmp_wrappers/ocmp_debugocgpio.c $(OCWARE_ROOT)/src/drivers/OcGpio.c fake/fake_GPIO.c fake/fake_I2C.c fake/fake_ThreadedISR.c fake/fake_debugocgpio.c fake/fake_SX1509_register.c fake/fake_PCA9557.c stub/stub_GateMutex.c $(OCWARE_ROOT)/src/drivers/GpioPCA9557.c $(OCWARE_ROOT)/src/devices/pca9557.c $(OCWARE_ROOT)/src/drivers/GpioSX1509.c $(OCWARE_ROOT)/src/devices/sx1509.c $(OCWARE_ROOT)/src/devices/i2cbus.c $(OCWARE_ROOT)/src/helpers/memory.c $(OCWARE_ROOT)/platform/oc-sdr/cfg/OC_CONNECT_GBC.c $(OCWARE_ROOT)/platform/oc-sdr/cfg/OC_CONNECT_SDR.c
+$(PATHB)Test_ocmp_debugocgpio$(TARGET_EXTENSION): $(STD_FILES) $(TEST_OCMP_DEBUGOCGPIO_SRC)
+
 $(PATHB)%$(TARGET_EXTENSION):
 	$(C_COMPILER) $(CFLAGS) $(INC_DIRS) $(SYMBOLS) $^ -o $@    
 	$(COV_CMDS)

--- a/firmware/ec/test/fake/fake_debugocgpio.c
+++ b/firmware/ec/test/fake/fake_debugocgpio.c
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+#include "include/test_debugocgpio.h"
+
+OcGpio_Port gbc_io_1 = {
+    .fn_table = &GpioSX1509_fnTable,
+    .cfg =
+        &(SX1509_Cfg){
+            .i2c_dev = { OC_CONNECT1_I2C0, GBC_IO_1_SLAVE_ADDR },
+            .pin_irq = NULL, /* This IO expander doesn't provide interrupts */
+        },
+    .object_data = &(SX1509_Obj){},
+};
+
+OcGpio_Port ec_io = {
+    .fn_table = &FakeGpio_fnTable,
+    .object_data = &(FakeGpio_Obj){},
+};
+
+OcGpio_Port sdr_fx3_io = {
+    .fn_table = &GpioPCA9557_fnTable,
+    .cfg =
+        &(PCA9557_Cfg){
+            .i2c_dev = { OC_CONNECT1_I2C3, SDR_FX3_IOEXP_ADDRESS },
+        },
+    .object_data = &(PCA9557_Obj){},
+};
+
+OcGpio_Port sdr_fx3_io_invalid = {
+    .fn_table = &GpioPCA9557_fnTable,
+    .cfg =
+        &(PCA9557_Cfg){
+            .i2c_dev = { OC_CONNECT1_I2C4, SDR_FX3_IO_INVALID_SLAVE_ADDR },
+        },
+    .object_data = &(PCA9557_Obj){},
+};
+
+S_OCGPIO_Cfg debug_sdr_ioexpanderx1E_invalid = {
+    .port = &sdr_fx3_io_invalid,
+    .group = 1,
+};
+
+bool DEBUG_GpioPins[] = {
+    [DEBUG_GPIO_PIN_1] = OCGPIO_CFG_INPUT,
+    [DEBUG_GPIO_PIN_2] = OCGPIO_CFG_INPUT,
+};
+
+uint32_t DEBUG_GpioConfig[] = {
+    [DEBUG_GPIO_PIN_1] = OCGPIO_CFG_INPUT,
+    [DEBUG_GPIO_PIN_2] = OCGPIO_CFG_INPUT,
+};
+
+S_OCGPIO s_fake_pin = {
+    .pin = DEBUG_GPIO_S_FAKE_PIN,
+};
+
+S_OCGPIO s_sx1509_invalid_pin = {
+    .pin = DEBUG_GPIO_SX1509_INALID_PIN,
+};
+
+S_OCGPIO s_pca9557_invalid_pin = {
+    .pin = DEBUG_GPIO_PCA9557_INVALID_PIN,
+};

--- a/firmware/ec/test/include/test_debugocgpio.h
+++ b/firmware/ec/test/include/test_debugocgpio.h
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+#ifndef _TEST_DEBUGOCGPIO_H
+#define _TEST_DEBUGOCGPIO_H
+
+#include "common/inc/global/OC_CONNECT1.h"
+#include "common/inc/ocmp_wrappers/ocmp_debugocgpio.h"
+#include "fake/fake_GPIO.h"
+#include "fake/fake_I2C.h"
+#include "inc/devices/debug_ocgpio.h"
+#include "include/test_PCA9557.h"
+#include "include/test_sx1509.h"
+#include "src/drivers/GpioSX1509.h"
+#include "src/drivers/GpioPCA9557.h"
+#include <string.h>
+#include "ti/drivers/gpio/GPIOTiva.h"
+#include <ti/sysbios/knl/Task.h>
+#include "unity.h"
+
+#define DEBUG_GPIO_DEFAULT_VALUE 0x00
+#define DEBUG_GPIO_PCA9557_INVALID_PIN 8
+#define DEBUG_GPIO_PIN_VALUE 1
+#define DEBUG_GPIO_PIN_1 0x01
+#define DEBUG_GPIO_PIN_2 0x02
+#define DEBUG_GPIO_S_FAKE_PIN 2
+#define DEBUG_GPIO_SX1509_DATA_A_VALUE 0xff
+#define DEBUG_GPIO_SX1509_DATA_B_VALUE 0x02
+#define DEBUG_GPIO_SX1509_INALID_PIN 16
+#define GBC_IO_1_SLAVE_ADDR 0x45
+#define SDR_FX3_IO_INVALID_SLAVE_ADDR 0xFF
+#endif

--- a/firmware/ec/test/suites/Test_ocmp_debugocgpio.c
+++ b/firmware/ec/test/suites/Test_ocmp_debugocgpio.c
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+#include "include/test_debugocgpio.h"
+
+/* ============================= Fake Functions ============================= */
+
+unsigned int s_task_sleep_ticks;
+xdc_Void ti_sysbios_knl_Task_sleep__E(xdc_UInt32 nticks)
+{
+    s_task_sleep_ticks += nticks;
+}
+
+GPIO_PinConfig gpioPinConfigs[OC_EC_GPIOCOUNT] = {
+    /* fake define */
+};
+
+/* ======================== Constants & variables =========================== */
+extern bool DEBUG_GpioPins[DEBUG_GPIO_PIN_2];
+extern S_OCGPIO s_fake_pin;
+extern S_OCGPIO s_pca9557_invalid_pin;
+extern S_OCGPIO s_sx1509_invalid_pin;
+extern S_OCGPIO_Cfg debug_sdr_ioexpanderx1E_invalid;
+extern S_OCGPIO_Cfg debug_ec_gpio_pa;
+extern S_OCGPIO_Cfg debug_gbc_ioexpanderx70;
+extern S_OCGPIO_Cfg debug_sdr_ioexpanderx1E;
+extern uint8_t PCA9557_regs[PCA9557_REGS_END];
+extern uint8_t SX1509_regs[SX1509_REG_TEST_2];
+extern uint32_t DEBUG_GpioConfig[DEBUG_GPIO_PIN_2];
+/* ============================= Boilerplate ================================ */
+void suite_setUp(void)
+{
+    fake_I2C_init();
+    fake_I2C_registerDevSimple(OC_CONNECT1_I2C0, GBC_IO_1_SLAVE_ADDR,
+                               &SX1509_regs, sizeof(SX1509_regs),
+                               sizeof(SX1509_regs[0]), sizeof(uint8_t),
+                               FAKE_I2C_DEV_LITTLE_ENDIAN);
+    fake_I2C_registerDevSimple(OC_CONNECT1_I2C3, SDR_FX3_IOEXP_ADDRESS,
+                               &PCA9557_regs, sizeof(PCA9557_regs),
+                               sizeof(PCA9557_regs[0]), sizeof(uint8_t),
+                               FAKE_I2C_DEV_LITTLE_ENDIAN);
+    FakeGpio_registerDevSimple(DEBUG_GpioPins, DEBUG_GpioConfig);
+}
+
+void setUp(void)
+{
+}
+
+void tearDown(void)
+{
+}
+
+void suite_tearDown(void)
+{
+    fake_I2C_deinit(); /* This will automatically unregister devices */
+}
+/* ================================ Tests =================================== */
+void test_ocgpio_get(void)
+{
+    S_OCGPIO *s_oc_gpio = (S_OCGPIO *)&s_fake_pin;
+    s_oc_gpio->pin = DEBUG_GPIO_PIN_VALUE;
+    s_oc_gpio->value = DEBUG_GPIO_DEFAULT_VALUE;
+
+    PCA9557_regs[PCA9557_REGS_INPUT_VALUE] = DEBUG_GPIO_PIN_2;
+    SX1509_regs[SX1509_REG_DATA_B] = DEBUG_GPIO_SX1509_DATA_B_VALUE;
+    SX1509_regs[SX1509_REG_DATA_A] = DEBUG_GPIO_SX1509_DATA_A_VALUE;
+    DEBUG_GpioPins[DEBUG_GPIO_PIN_2] = OCGPIO_CFG_OUTPUT;
+    /* Native Pin */
+    TEST_ASSERT_EQUAL(true, ocgpio_get(&debug_ec_gpio_pa, &s_fake_pin));
+    TEST_ASSERT_EQUAL(DEBUG_GPIO_PIN_VALUE, s_oc_gpio->value);
+
+    /* connected via SX1509 */
+    TEST_ASSERT_EQUAL(true, ocgpio_get(&debug_gbc_ioexpanderx70, &s_fake_pin));
+    TEST_ASSERT_EQUAL(DEBUG_GPIO_PIN_VALUE, s_oc_gpio->value);
+
+    /* connected via PCA9557 */
+    TEST_ASSERT_EQUAL(true, ocgpio_get(&debug_sdr_ioexpanderx1E, &s_fake_pin));
+    TEST_ASSERT_EQUAL(DEBUG_GPIO_PIN_VALUE, s_oc_gpio->value);
+
+    /* Invlaid Slave address */
+    TEST_ASSERT_EQUAL(
+        false, ocgpio_get(&debug_sdr_ioexpanderx1E_invalid, &s_fake_pin));
+}
+void test_ocgpio_set(void)
+{
+    S_OCGPIO *s_oc_gpio = (S_OCGPIO *)&s_fake_pin;
+    s_oc_gpio->pin = DEBUG_GPIO_PIN_2;
+    s_oc_gpio->value = DEBUG_GPIO_DEFAULT_VALUE;
+
+    PCA9557_regs[PCA9557_REGS_OUTPUT_VALUE] = DEBUG_GPIO_DEFAULT_VALUE;
+    SX1509_regs[SX1509_REG_DATA_B] = DEBUG_GPIO_DEFAULT_VALUE;
+    SX1509_regs[SX1509_REG_DATA_A] = DEBUG_GPIO_DEFAULT_VALUE;
+    DEBUG_GpioPins[DEBUG_GPIO_PIN_2] = OCGPIO_CFG_INPUT;
+    /* Native Pin */
+    TEST_ASSERT_EQUAL(true, ocgpio_set(&debug_ec_gpio_pa, &s_fake_pin));
+    TEST_ASSERT_EQUAL(OCGPIO_CFG_OUTPUT, DEBUG_GpioPins[DEBUG_GPIO_PIN_2]);
+
+    /* connected via SX1509 */
+    TEST_ASSERT_EQUAL(true, ocgpio_set(&debug_gbc_ioexpanderx70, &s_fake_pin));
+    TEST_ASSERT_EQUAL(DEBUG_GPIO_DEFAULT_VALUE, SX1509_regs[SX1509_REG_DATA_A]);
+
+    /* connected via PCA9557 */
+    TEST_ASSERT_EQUAL(true, ocgpio_set(&debug_sdr_ioexpanderx1E, &s_fake_pin));
+    TEST_ASSERT_EQUAL(DEBUG_GPIO_DEFAULT_VALUE,
+                      PCA9557_regs[PCA9557_REGS_OUTPUT_VALUE]);
+
+    /* Invlaid Slave address */
+    TEST_ASSERT_EQUAL(
+        false, ocgpio_set(&debug_sdr_ioexpanderx1E_invalid, &s_fake_pin));
+}
+void test_ocgpio_probe(void)
+{
+    /* TODO: separately tracked as #117
+     */
+}
+
+void test_ocgpio_init(void)
+{
+    TEST_ASSERT_EQUAL(POST_DEV_CFG_DONE, DEBUG_OCGPIO_fxnTable.cb_init(
+                                             &debug_ec_gpio_pa, NULL, NULL));
+}


### PR DESCRIPTION
## Summary
Valid configuration has been taken from the /ec/platform/oc-sdr/cfg/OC_CONNECT_GBC.c, /ec/platform/oc-sdr/cfg/OC_CONNECT_SDR.c and /ec/platform/oc-sdr/cfg/OC_CONNECT_RF.c for the test cases.

## Test Plan
Run Unit Tests (make clean test) and verify that all tests pass including new test cases.
Run firmware build and verify no error is reported.

## Issues
#123
